### PR TITLE
Some enhancements to the existing work to simplify

### DIFF
--- a/Dockerfile.centos.7
+++ b/Dockerfile.centos.7
@@ -30,3 +30,5 @@ RUN usermod -a -G mock $USER
 # mock in Docker needs to use the old-chroot option
 RUN grep use_nspawn || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
+
+RUN chmod g+w /etc/mock/default.cfg

--- a/Dockerfile.leap.15
+++ b/Dockerfile.leap.15
@@ -31,8 +31,8 @@ RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
-    chmod 0440 /etc/sudoers.d/build; \
-    visudo -c; \
+    chmod 0440 /etc/sudoers.d/build;                                        \
+    visudo -c;                                                              \
     sudo -l -U build
 
 ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"

--- a/Dockerfile.leap.15
+++ b/Dockerfile.leap.15
@@ -17,40 +17,29 @@ RUN useradd -u $UID -ms /bin/bash $USER
 RUN groupadd -g $UID $USER
 
 # Install basic tools
-RUN zypper --non-interactive update
+RUN zypper --non-interactive up
 
 # basic building
-ENV RELVER="15.1"
-ENV OPENSUSE_REPO="https://download.opensuse.org/repositories" \
-    UPDATES_REPO="https://download.opensuse.org/update/leap/${RELVER}" \
-    DIST_REPO="http://download.opensuse.org/distribution/leap/${RELVER}/repo"
-ENV TOOLS_15A="openSUSE:/Tools/openSUSE_${RELVER}/openSUSE:Tools.repo"
-ENV TOOLS_15="${OPENSUSE_REPO}/${TOOLS_15A}" \
-    DIST_OSS_15="${DIST_REPO}/oss" \
-    UPD_OSS_15="${UPDATES_REPO}/oss/openSUSE:Leap:${RELVER}:Update.repo"
+RUN zypper --non-interactive in autoconf automake                        \
+                                ca-certificates-mozilla curl createrepo  \
+                                git libtool lsb-release make             \
+                                perl-libwww-perl perl-LWP-Protocol-https \
+                                perl-XML-Parser rpm-build sudo
 
-# Build in repos have macros with $releasever not working for build,
-# so need to be replaced.
-# Two different syntax for ar depending on if the repository provides a .repo
-RUN zypper --non-interactive mr --disable repo-update; \
-    zypper --non-interactive mr --disable repo-oss; \
-    zypper --non-interactive ar -f ${TOOLS_15}; \
-    zypper --non-interactive ar -f ${DIST_OSS_15} distro-repo-oss; \
-    zypper --non-interactive ar -f ${UPD_OSS_15}; \
-    zypper --non-interactive --gpg-auto-import-keys refresh
-
-RUN zypper --non-interactive --no-gpg-checks refresh; \
-    zypper --non-interactive install autoconf automake build                  \
-                                     ca-certificates-mozilla curl createrepo  \
-                                     git libtool lsb-release make             \
-                                     perl-libwww-perl perl-LWP-Protocol-https \
-                                     perl-XML-Parser rpm-build sudo
-
-# need to run the zypper and build command as root, as it needs to chroot
-RUN echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build ; \
-    echo "build ALL=(ALL) NOPASSWD: " \
-    "/usr/bin/zypper --non-interactive --no-gpg-checks refresh" \
-     >> /etc/sudoers.d/build; \
+# need to run the build command as root, as it needs to chroot
+RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
+        echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
+    fi;                                                                     \
+    echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
     chmod 0440 /etc/sudoers.d/build; \
     visudo -c; \
     sudo -l -U build
+
+ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
+ENV TOOLS="${OPENSUSE_REPO}/openSUSE:Tools/openSUSE_15.1/openSUSE:Tools.repo"
+
+RUN set -x; zypper --non-interactive ar ${TOOLS}; \
+    zypper --non-interactive --gpg-auto-import-keys ref \
+      'openSUSE.org tools (openSUSE_15.1)'
+
+RUN zypper --non-interactive in build

--- a/Dockerfile.leap.42.3
+++ b/Dockerfile.leap.42.3
@@ -20,19 +20,19 @@ RUN groupadd -g $UID $USER
 RUN zypper --non-interactive up
 
 # basic building
-RUN zypper --non-interactive in autoconf automake                       \
-                                     ca-certificates-mozilla curl createrepo  \
-                                     git libtool lsb-release make             \
-                                     perl-libwww-perl perl-LWP-Protocol-https \
-                                     perl-XML-Parser rpm-build sudo
+RUN zypper --non-interactive in autoconf automake                        \
+                                ca-certificates-mozilla curl createrepo  \
+                                git libtool lsb-release make             \
+                                perl-libwww-perl perl-LWP-Protocol-https \
+                                perl-XML-Parser rpm-build sudo
 
 # need to run the build command as root, as it needs to chroot
 RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
-    chmod 0440 /etc/sudoers.d/build; \
-    visudo -c; \
+    chmod 0440 /etc/sudoers.d/build;                                        \
+    visudo -c;                                                              \
     sudo -l -U build
 
 ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"

--- a/Dockerfile.leap.42.3
+++ b/Dockerfile.leap.42.3
@@ -17,50 +17,29 @@ RUN useradd -u $UID -ms /bin/bash $USER
 RUN groupadd -g $UID $USER
 
 # Install basic tools
-RUN zypper --non-interactive update
+RUN zypper --non-interactive up
 
 # basic building
-ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
-ENV TOOLS_42_3A="openSUSE:/Tools/openSUSE_42.3/openSUSE:Tools.repo"
-ENV TOOLS_42_3="${OPENSUSE_REPO}/${TOOLS_42_3A}"
-ENV HPC_42_3="${OPENSUSE_REPO}/science:/HPC/openSUSE_Leap_42.3"
-
-# Two different syntax for ar depending on if the repository provides a .repo
-RUN zypper --non-interactive ar -f ${TOOLS_42_3}; \
-    zypper --non-interactive ar -f ${HPC_42_3}/science:HPC.repo; \
-    zypper --non-interactive --gpg-auto-import-keys refresh
-
-RUN zypper --non-interactive --no-gpg-checks refresh; \
-    zypper --non-interactive install autoconf automake build                  \
+RUN zypper --non-interactive in autoconf automake                       \
                                      ca-certificates-mozilla curl createrepo  \
                                      git libtool lsb-release make             \
                                      perl-libwww-perl perl-LWP-Protocol-https \
                                      perl-XML-Parser rpm-build sudo
 
-# need to run the zypper and build command as root, as it needs to chroot
-RUN echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build ; \
-    echo "build ALL=(ALL) NOPASSWD: " \
-    "/usr/bin/zypper --non-interactive --no-gpg-checks refresh" \
-     >> /etc/sudoers.d/build; \
+# need to run the build command as root, as it needs to chroot
+RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
+        echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
+    fi;                                                                     \
+    echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
     chmod 0440 /etc/sudoers.d/build; \
     visudo -c; \
     sudo -l -U build
 
+ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
+ENV TOOLS="${OPENSUSE_REPO}/openSUSE:Tools/openSUSE_42.3/openSUSE:Tools.repo"
 
-# Suse build utility can not handle spaces in the repo aliases.
-RUN zypper --non-interactive nr 'NON OSS' NON_OSS; \
-    zypper --non-interactive nr 'NON OSS Update' NON_OSS_Update; \
-    zypper --non-interactive nr 'OSS Update' OSS_Update
+RUN set -x; zypper --non-interactive ar ${TOOLS}; \
+    zypper --non-interactive --gpg-auto-import-keys ref \
+      'openSUSE.org tools (openSUSE_42.3)'
 
-# Need the repo for munge
-ARG JENKINS_URL=""
-ENV JENKINS_PATH="${JENKINS_URL}job/daos-stack/job"
-ENV JENKINS_ART="lastSuccessfulBuild/artifact/artifacts"
-ARG MNGE_BRANCH="master"
-RUN zypper --non-interactive ar --gpgcheck-allow-unsigned -f \
-    ${JENKINS_PATH}/munge/job/${MNGE_BRANCH}/${JENKINS_ART}/leap42.3 munge; \
-    zypper --non-interactive ref munge
-
-# These repositories can only be used by suse build if passed with a repo
-# command.
-RUN echo " --repo ${HPC_42_3}" > /tmp/build.repos
+RUN zypper --non-interactive in build

--- a/Dockerfile.leap.42.3
+++ b/Dockerfile.leap.42.3
@@ -31,6 +31,7 @@ RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
+    echo "build ALL=(ALL) NOPASSWD: /bin/rpm" >> /etc/sudoers.d/build;      \
     chmod 0440 /etc/sudoers.d/build;                                        \
     visudo -c;                                                              \
     sudo -l -U build

--- a/Dockerfile.sles.12.3
+++ b/Dockerfile.sles.12.3
@@ -17,66 +17,29 @@ RUN useradd -u $UID -ms /bin/bash $USER
 RUN groupadd -g $UID $USER
 
 # Install basic tools
-RUN zypper --non-interactive --no-gpg-checks refresh; \
-    zypper --non-interactive update
+RUN zypper --non-interactive up
 
 # basic building
-# SLES-12SP3 needs ca-certificates-mozilla before adding the repos.
-RUN zypper --non-interactive --no-gpg-checks refresh; \
-    zypper --non-interactive install ca-certificates-mozilla
+RUN zypper --non-interactive in autoconf automake                        \
+                                ca-certificates-mozilla curl createrepo  \
+                                git libtool lsb-release make             \
+                                perl-libwww-perl perl-LWP-Protocol-https \
+                                perl-XML-Parser rpm-build sudo
 
-ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
-ENV TOOLS_12_3A="openSUSE:/Tools/SLE_12_SP3/openSUSE:Tools.repo"
-ENV TOOLS_12_3="${OPENSUSE_REPO}/${TOOLS_12_3A}"
-ENV HPC_12_3A="science:/HPC:/SLE12SP3_Missing/SLE_12_SP3"
-ENV HPC_12_3="${OPENSUSE_REPO}/${HPC_12_3A}/"
-ENV HPC_42_3="${OPENSUSE_REPO}/science:/HPC/openSUSE_Leap_42.3"
-
-# Two different syntax for ar depending on if the repository provides a .repo
-RUN zypper --non-interactive ar -f ${TOOLS_12_3}; \
-    zypper --non-interactive ar -f ${HPC_42_3}/science:HPC.repo; \
-    zypper --non-interactive ar -f ${HPC_12_3} Science_HPC_SLE_12_SP3; \
-    zypper --non-interactive --gpg-auto-import-keys refresh
-
-RUN zypper --non-interactive --no-gpg-checks refresh; \
-    zypper --non-interactive install autoconf automake build curl createrepo  \
-                                     git libtool lsb-release make             \
-                                     perl-libwww-perl perl-LWP-Protocol-https \
-                                     perl-XML-Parser rpm-build sudo
-
-# need to run the zypper and build command as root, as it needs to chroot
-RUN echo "#includedir /etc/sudoers.d" >> /etc/sudoers; \
+# need to run the build command as root, as it needs to chroot
+RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
+        echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
+    fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build ; \
-    echo "build ALL=(ALL) NOPASSWD: " \
-    "/usr/bin/zypper --non-interactive --no-gpg-checks refresh" \
-     >> /etc/sudoers.d/build ; \
     chmod 0440 /etc/sudoers.d/build; \
     visudo -c; \
     sudo -l -U build
                              
-#Temp patch until base docker image rebuilt
-#Disable older SLES repositories.
-RUN zypper --non-interactive mr --disable http-10.8.0.10-099eb6aa; \
-    zypper --non-interactive mr --disable http-10.8.0.10-2a04a526; \
-    zypper --non-interactive mr --disable http-10.8.0.10-33b60288; \
-    zypper --non-interactive mr --disable http-10.8.0.10-4e00da6f; \
-    zypper --non-interactive mr --disable http-10.8.0.10-82d67f5b; \
-    zypper --non-interactive mr --disable http-10.8.0.10-ae069f46; \
-    zypper --non-interactive mr --disable http-10.8.0.10-b2e5365a; \
-    zypper --non-interactive mr --disable http-10.8.0.10-c059c690 || true
+ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
+ENV TOOLS="${OPENSUSE_REPO}/openSUSE:Tools/SLE_12_SP3/openSUSE:Tools.repo"
 
-ARG JENKINS_URL=""
-ENV JENKINS_PATH="${JENKINS_URL}job/daos-stack/job"
-ENV JENKINS_ART="lastSuccessfulBuild/artifact/artifacts"
-ARG MNGE_BRANCH="master"
-RUN zypper --non-interactive ar --gpgcheck-allow-unsigned -f \
-    ${JENKINS_PATH}/munge/job/${MNGE_BRANCH}/${JENKINS_ART}/sles12.3/ munge; \
-    zypper --non-interactive ref munge
+RUN set -x; zypper --non-interactive ar ${TOOLS}; \
+    zypper --non-interactive --gpg-auto-import-keys ref \
+      'openSUSE.org tools (SLE_12_SP3)'
 
-# These repositories can only be used by suse build if passed with a repo
-# command.
-RUN echo " --repo ${HPC_42_3}" \
-    "--repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64" \
-    "--repo http://cobbler/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64" \
-    "--repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64" > \
-    /tmp/build.repos
+RUN zypper --non-interactive in build

--- a/Dockerfile.sles.12.3
+++ b/Dockerfile.sles.12.3
@@ -30,11 +30,11 @@ RUN zypper --non-interactive in autoconf automake                        \
 RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
-    echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build ; \
-    chmod 0440 /etc/sudoers.d/build; \
-    visudo -c; \
+    echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
+    chmod 0440 /etc/sudoers.d/build;                                        \
+    visudo -c;                                                              \
     sudo -l -U build
-                             
+
 ENV OPENSUSE_REPO="https://download.opensuse.org/repositories"
 ENV TOOLS="${OPENSUSE_REPO}/openSUSE:Tools/SLE_12_SP3/openSUSE:Tools.repo"
 

--- a/Dockerfile.sles.12.3
+++ b/Dockerfile.sles.12.3
@@ -31,6 +31,7 @@ RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
+    echo "build ALL=(ALL) NOPASSWD: /bin/rpm" >> /etc/sudoers.d/build;      \
     chmod 0440 /etc/sudoers.d/build;                                        \
     visudo -c;                                                              \
     sudo -l -U build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
                                   cp -af _topdir/SRPMS $artdir
                                   (cd $mockroot/result/ &&
                                    cp -r . $artdir)
-                                  (cd $mockroot/root/builddir/build/BUILD/*/
+                                  (if cd $mockroot/root/builddir/build/BUILD/*/; then
                                    find . -name configure -printf %h\\\\n | \
                                    while read dir; do
                                        if [ ! -f $dir/config.log ]; then
@@ -110,7 +110,8 @@ pipeline {
                                        tdir="$artdir/autoconf-logs/$dir"
                                        mkdir -p $tdir
                                        cp -a $dir/config.log $tdir/
-                                   done)'''
+                                   done
+                                   fi)'''
                         }
                         cleanup {
                             archiveArtifacts artifacts: 'artifacts/centos7/**'
@@ -118,8 +119,10 @@ pipeline {
                     }
                 } //stage('Build on CentOS 7')
                 stage('Build on SLES 12.3') {
-                    when { beforeAgent true
-                           environment name: 'SLES12_3_DOCKER', value: 'true' }
+                    when {
+                        beforeAgent true
+                        environment name: 'SLES12_3_DOCKER', value: 'true'
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.sles.12.3'
@@ -148,7 +151,7 @@ pipeline {
                             sh '''mockbase=/var/tmp/build-root/home/abuild
                                   mockroot=$mockbase/rpmbuild
                                   artdir=$PWD/artifacts/sles12.3
-                                  (cd $mockroot/BUILD &&
+                                  (if cd $mockroot/BUILD; then
                                    find . -name configure -printf %h\\\\n | \
                                    while read dir; do
                                        if [ ! -f $dir/config.log ]; then
@@ -157,7 +160,8 @@ pipeline {
                                        tdir="$artdir/autoconf-logs/$dir"
                                        mkdir -p $tdir
                                        cp -a $dir/config.log $tdir/
-                                   done)'''
+                                       done
+                                   fi)'''
                         }
                         cleanup {
                             archiveArtifacts artifacts: 'artifacts/sles12.3/**'
@@ -193,7 +197,7 @@ pipeline {
                             sh '''mockbase=/var/tmp/build-root/home/abuild
                                   mockroot=$mockbase/rpmbuild
                                   artdir=$PWD/artifacts/leap42.3
-                                  (cd $mockroot/BUILD &&
+                                  (if cd $mockroot/BUILD; then
                                    find . -name configure -printf %h\\\\n | \
                                    while read dir; do
                                        if [ ! -f $dir/config.log ]; then
@@ -202,7 +206,8 @@ pipeline {
                                        tdir="$artdir/autoconf-logs/$dir"
                                        mkdir -p $tdir
                                        cp -a $dir/config.log $tdir/
-                                   done)'''
+                                       done
+                                   fi)'''
                         }
                         cleanup {
                             archiveArtifacts artifacts: 'artifacts/leap42.3/**'
@@ -238,7 +243,7 @@ pipeline {
                             sh '''mockbase=/var/tmp/build-root/home/abuild
                                   mockroot=$mockbase/rpmbuild
                                   artdir=$PWD/artifacts/leap15
-                                  (cd $mockroot/BUILD &&
+                                  (if cd $mockroot/BUILD; then
                                    find . -name configure -printf %h\\\\n | \
                                    while read dir; do
                                        if [ ! -f $dir/config.log ]; then
@@ -247,7 +252,8 @@ pipeline {
                                        tdir="$artdir/autoconf-logs/$dir"
                                        mkdir -p $tdir
                                        cp -a $dir/config.log $tdir/
-                                   done)'''
+                                       done
+                                   fi)'''
                         }
                         cleanup {
                             archiveArtifacts artifacts: 'artifacts/leap15/**'

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,3 @@ SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
 include Makefile_packaging.mk
-

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -265,7 +265,7 @@ chrootbuild: $(SRPM) Makefile
             add_repos+=" --repo $$baseurl";                                 \
         done;                                                               \
 	sudo build --nosignature $(BUILD_OPTIONS) $$add_repos               \
-	     $($(basename DISTRO_ID)_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
+	     $($(basename $(DISTRO_ID))_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
 	     $(SRPM)
 endif
 

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -229,15 +229,15 @@ gpgcheck = False\n" >> /etc/mock/default.cfg;                                   
 	echo "\"\"\"" >> /etc/mock/default.cfg
 	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
 else
-sle12.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/x86_64/ \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                    \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/sdk-sles12.3-x86_64                           \
-	         --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/    \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/updates-sles12.3-x86_64                       \
+sle12.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/     \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                 \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
+	         --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
 	         --repo http://mgmt-1.wolf.hpdd.intel.com/cobbler/pub/SLES-12.3-x86_64/
 
-sl42.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/x86_64/ \
-	        --repo http://download.opensuse.org/update/leap/42.3/oss/                                 \
+sl42.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3 \
+	        --repo http://download.opensuse.org/update/leap/42.3/oss/                         \
 	        --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
 
 sl15.1_REPOS += --repo http://download.opensuse.org/update/leap/15.1/oss/            \

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -237,10 +237,10 @@ gpgcheck = False\n" >> /etc/mock/default.cfg;                                   
 	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
 else
 sle12_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/     \
-	       --repo http://cobbler/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                 \
-	       --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
+	       --repo http://cobbler/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                   \
+	       --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64                          \
 	       --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
-	       --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
+	       --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64                      \
 	       --repo http://cobbler/cobbler/pub/SLES-12.3-x86_64/
 
 sl42_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3 \
@@ -271,9 +271,11 @@ chrootbuild: $(SRPM) Makefile
 	    baseurl+=lastSuccessfulBuild/artifact/artifacts/$$distro/;      \
             add_repos+=" --repo $$baseurl";                                 \
         done;                                                               \
-	sudo build --nosignature $(BUILD_OPTIONS) $$add_repos               \
-	     $($(basename $(DISTRO_ID))_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
-	     $(SRPM)
+	curl -O http://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/repodata/repomd.xml.key; \
+	sudo rpm --import repomd.xml.key;                                   \
+	sudo build $(BUILD_OPTIONS) $$add_repos                             \
+	     $($(basename $(DISTRO_ID))_REPOS)                              \
+	     --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) $(SRPM)
 endif
 
 docker_chrootbuild:

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -229,19 +229,19 @@ gpgcheck = False\n" >> /etc/mock/default.cfg;                                   
 	echo "\"\"\"" >> /etc/mock/default.cfg
 	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
 else
-sle12.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/     \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                 \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
-	         --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
-	         --repo http://mgmt-1.wolf.hpdd.intel.com/cobbler/pub/SLES-12.3-x86_64/
+sle12_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/     \
+	       --repo http://cobbler/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                 \
+	       --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
+	       --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
+	       --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
+	       --repo http://mgmt-1.wolf.hpdd.intel.com/cobbler/pub/SLES-12.3-x86_64/
 
-sl42.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3 \
-	        --repo http://download.opensuse.org/update/leap/42.3/oss/                         \
-	        --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
+sl42_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3 \
+	      --repo http://download.opensuse.org/update/leap/42.3/oss/                         \
+	      --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
 
-sl15.1_REPOS += --repo http://download.opensuse.org/update/leap/15.1/oss/            \
-	        --repo http://download.opensuse.org/distribution/leap/15.1/repo/oss/
+sl15_REPOS += --repo http://download.opensuse.org/update/leap/15.1/oss/            \
+	      --repo http://download.opensuse.org/distribution/leap/15.1/repo/oss/
 
 chrootbuild: $(SRPM) Makefile
 	add_repos="";                                                       \
@@ -265,7 +265,7 @@ chrootbuild: $(SRPM) Makefile
             add_repos+=" --repo $$baseurl";                                 \
         done;                                                               \
 	sudo build --nosignature $(BUILD_OPTIONS) $$add_repos               \
-	     $($(DISTRO_ID)_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
+	     $($(basename DISTRO_ID)_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
 	     $(SRPM)
 endif
 

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -264,8 +264,9 @@ chrootbuild: $(SRPM) Makefile
 	    baseurl+=lastSuccessfulBuild/artifact/artifacts/$$distro/;      \
             add_repos+=" --repo $$baseurl";                                 \
         done;                                                               \
-	sudo build $(BUILD_OPTIONS) $$add_repos $($(DISTRO_ID)_REPOS)       \
-	  --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) $(SRPM)
+	sudo build --nosignature $(BUILD_OPTIONS) $$add_repos               \
+	     $($(DISTRO_ID)_REPOS) --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) \
+	     $(SRPM)
 endif
 
 rpmlint: $(SPEC)

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -24,6 +24,7 @@ DISTRO_ID := sle$(VERSION_ID)
 endif
 
 BUILD_OS ?= leap.42.3
+PACKAGING_CHECK_DIR ?= ../packaging
 COMMON_RPM_ARGS := --define "%_topdir $$PWD/_topdir"
 DIST    := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 ifeq ($(DIST),)
@@ -235,7 +236,7 @@ sle12_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/op
 	       --repo http://cobbler/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
 	       --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
 	       --repo http://cobbler/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
-	       --repo http://mgmt-1.wolf.hpdd.intel.com/cobbler/pub/SLES-12.3-x86_64/
+	       --repo http://cobbler/cobbler/pub/SLES-12.3-x86_64/
 
 sl42_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3 \
 	      --repo http://download.opensuse.org/update/leap/42.3/oss/                         \
@@ -273,24 +274,23 @@ endif
 docker_chrootbuild:
 	docker build --build-arg UID=$$(id -u) -t $(BUILD_OS)-chrootbuild \
 	             -f packaging/Dockerfile.$(BUILD_OS) .
-	docker run --privileged=true -w /home/brian/daos/rpm/openpa           \
-	           -v=/home/brian/daos/rpm/openpa:/home/brian/daos/rpm/openpa \
+	docker run --privileged=true -w $$PWD -v=$$PWD:$$PWD              \
 	           -it $(BUILD_OS)-chrootbuild bash -c "make chrootbuild"
 
 rpmlint: $(SPEC)
 	rpmlint $<
 
 packaging_check:
-	diff --exclude \*.sw?              \
-	     --exclude debian              \
-	     --exclude .git                \
-	     --exclude Jenkinsfile         \
-	     --exclude libfabric.spec      \
-	     --exclude Makefile            \
-	     --exclude README.md           \
-	     --exclude _topdir             \
-	     --exclude \*.tar.\*           \
-	     -ur ../packaging/ packaging/
+	diff --exclude \*.sw?                       \
+	     --exclude debian                       \
+	     --exclude .git                         \
+	     --exclude Jenkinsfile                  \
+	     --exclude libfabric.spec               \
+	     --exclude Makefile                     \
+	     --exclude README.md                    \
+	     --exclude _topdir                      \
+	     --exclude \*.tar.\*                    \
+	     -ur $(PACKAGING_CHECK_DIR)/ packaging/
 
 check-env:
 ifndef DEBEMAIL

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -229,13 +229,15 @@ gpgcheck = False\n" >> /etc/mock/default.cfg;                                   
 	echo "\"\"\"" >> /etc/mock/default.cfg
 	mock $(MOCK_OPTIONS) $(RPM_BUILD_OPTIONS) $<
 else
-sle12.3_REPOS += --repo http://10.8.0.10/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                 \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/sdk-sles12.3-x86_64                        \
-	         --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/ \
-	         --repo http://10.8.0.10/cobbler/repo_mirror/updates-sles12.3-x86_64                    \
+sle12.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/x86_64/ \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/sdkupdate-sles12.3-x86_64/                    \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/sdk-sles12.3-x86_64                           \
+	         --repo http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/    \
+	         --repo http://10.8.0.10/cobbler/repo_mirror/updates-sles12.3-x86_64                       \
 	         --repo http://mgmt-1.wolf.hpdd.intel.com/cobbler/pub/SLES-12.3-x86_64/
 
-sl42.3_REPOS += --repo http://download.opensuse.org/update/leap/42.3/oss/                 \
+sl42.3_REPOS += --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/x86_64/ \
+	        --repo http://download.opensuse.org/update/leap/42.3/oss/                                 \
 	        --repo http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/
 
 sl15.1_REPOS += --repo http://download.opensuse.org/update/leap/15.1/oss/            \

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -1,4 +1,4 @@
-%define lib_major 1
+%define libname libfabric1
 
 Name: libfabric
 Version: 1.8.0
@@ -56,12 +56,12 @@ BuildRequires: autoconf, automake, libtool
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA.
 
-%package       -n %{name}%{?lib_major}
-Summary:        Shared library for libfabric
-Group:          System/Libraries
+%package -n %{libname}
+Summary: Shared library for libfabric
+Group:  System/Libraries
 Obsoletes: %{name} < %{version}-%{release}
 
-%description -n %{name}%{?lib_major}
+%description -n %{libname}
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA. This package contains the runtime library.
 
@@ -72,7 +72,7 @@ Group: Development/Libraries/C and C++
 %else
 Group: System Environment/Libraries
 %endif
-Requires: %{name}%{?lib_major}%{?_isa} = %{version}-%{release}
+Requires: %{libname}%{?_isa} = %{version}-%{release}
 
 %description devel
 libfabric provides a user-space API to access high-performance fabric
@@ -101,8 +101,8 @@ make %{?_smp_mflags} V=1
 rm -f %{buildroot}%{_libdir}/*.la
 %fdupes %{buildroot}/%{_prefix}
 
-%post -n libfabric%{lib_major} -p /sbin/ldconfig
-%postun -n libfabric%{lib_major} -p /sbin/ldconfig
+%post -n %{libname} -p /sbin/ldconfig
+%postun -n %{libname} -p /sbin/ldconfig
 
 %files
 %defattr(-,root,root,-)
@@ -111,7 +111,7 @@ rm -f %{buildroot}%{_libdir}/*.la
 %doc NEWS.md
 %license COPYING
 
-%files -n libfabric%{?lib_major}
+%files -n %{libname}
 %defattr(-,root,root)
 %{_libdir}/libfabric.so.*
 %license COPYING
@@ -126,8 +126,10 @@ rm -f %{buildroot}%{_libdir}/*.la
 %{_mandir}/man7/*
 
 %changelog
-* Fri Aug 09 2019 John E. Malmberg <john.e.malmberg@intel.com> - 1.8.0-1.1
-- Fixes to use suse build utility for building.
+* Fri Aug 16 2019 Brian J. Murrell <brian.murrell@intel.com> - 1.8.0-1
+- install libnl3-devel on all platforms
+- create a libfabric1 subpackage with the shared library
+- clean up much of SUSE's post build linting errors/warnings
 
 * Thu Jul 25 2019 Alexander A. Oganeozv <alexnader.a.oganezov@intel.com> - 1.8.0
 - Update to 1.8.0

--- a/libfabric.spec
+++ b/libfabric.spec
@@ -1,10 +1,12 @@
+%define lib_major 1
+
 Name: libfabric
 Version: 1.8.0
-Release: 1.1%{?dist}
+Release: 2%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 %if 0%{?suse_version} >= 1315
 License: GPL-2.0-only OR BSD-2-Clause
-Group: Development/Libraries/C and C++    
+Group: Development/Libraries/C and C++
 %else
 Group: System Environment/Libraries
 License: GPLv2 or BSD
@@ -14,19 +16,16 @@ Source: https://github.com/ofiwg/%{name}/archive/v%{version}.tar.gz
 
 %if 0%{?rhel} >= 7
 BuildRequires: librdmacm-devel
-BuildRequires: libibverbs-devel >= 1.2.0
-BuildRequires: libnl3-devel
 # needed for psm2_am_register_handlers_2@PSM2_1.0
 BuildRequires: libpsm2-devel >= 10.3.58
 %else
 %if 0%{?suse_version} >= 1315
-BuildRequires: libibverbs-devel >= 1.2.0
 BuildRequires: rdma-core-devel
+%endif
+%endif
+BuildRequires: libibverbs-devel >= 1.2.0
 BuildRequires: libnl3-devel
 BuildRequires: fdupes
-%define lib_major 1
-%endif
-%endif
 
 # infinipath-psm-devel only available for x86_64
 %ifarch x86_64
@@ -57,16 +56,14 @@ BuildRequires: autoconf, automake, libtool
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA.
 
-%if 0%{?suse_version} >= 01315
 %package       -n %{name}%{?lib_major}
-Summary:        User-space RDMA fabric interfaces
+Summary:        Shared library for libfabric
 Group:          System/Libraries
+Obsoletes: %{name} < %{version}-%{release}
 
 %description -n %{name}%{?lib_major}
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA. This package contains the runtime library.
-
-%endif
 
 %package devel
 Summary: Development files for the libfabric library
@@ -78,12 +75,8 @@ Group: System Environment/Libraries
 Requires: %{name}%{?lib_major}%{?_isa} = %{version}-%{release}
 
 %description devel
-%if 0%{?suse_version} >= 01315
 libfabric provides a user-space API to access high-performance fabric
-services, such as RDMA. This package contains the development files.    
-%else
-Development files for the libfabric library.
-%endif
+services, such as RDMA. This package contains the development files.
 
 %prep
 %setup -q
@@ -106,47 +99,27 @@ make %{?_smp_mflags} V=1
 %make_install
 # remove unpackaged files from the buildroot
 rm -f %{buildroot}%{_libdir}/*.la
-%if 0%{?suse_version} >= 01315
 %fdupes %{buildroot}/%{_prefix}
 
 %post -n libfabric%{lib_major} -p /sbin/ldconfig
 %postun -n libfabric%{lib_major} -p /sbin/ldconfig
-%else
 
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
-%endif
-
-%if 0%{?suse_version} >= 01315
 %files
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_mandir}/man1/*
 %doc NEWS.md
 %license COPYING
-%endif
 
 %files -n libfabric%{?lib_major}
-%if 0%{?suse_version} >= 01315
 %defattr(-,root,root)
-%endif    
 %{_libdir}/libfabric.so.*
-%if 0%{?rhel} >= 7
-%{_bindir}/fi_info
-%{_bindir}/fi_pingpong
-%{_bindir}/fi_strerror
-%{_libdir}/pkgconfig/%{name}.pc
-%{_mandir}/man1/*
-%endif
 %license COPYING
 %doc AUTHORS README
 
 %files devel
-%if 0%{?suse_version} >= 01315
 %defattr(-,root,root)
 %{_libdir}/pkgconfig/%{name}.pc
-
-%endif
 %{_libdir}/libfabric.so
 %{_includedir}/*
 %{_mandir}/man3/*


### PR DESCRIPTION
things I think.

Enhancements:
- short-circuits out of potential distracting non-error errors in artifact collection
- simplifies dockerfiles greatly
  - makes the suse ones almost identical
  - tempting to even autogenerate them from a single template.
- puts simplified package dependency <dep>[@branch[:build_number]] specification into the Makefile
  - consistent for suse and centos
- gives all repos to be used to build with --repo command
  - no assumptions/requirements on host repos
    - which means the build command is more portable to other environments
  - no needing to refresh repos in the host environment for build