### PR TITLE
Caller rpmbuild options; python-srpm-macros

### DIFF
--- a/Dockerfile.centos.7
+++ b/Dockerfile.centos.7
@@ -17,7 +17,7 @@ ARG UID=1000
 # Install basic tools
 RUN yum install -y epel-release
 RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git
+                   git python-srpm-macros
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -10,6 +10,7 @@ endif
 
 CALLING_MAKEFILE := $(word 1, $(MAKEFILE_LIST))
 
+RPM_BUILD_OPTIONS += $(EXTERNAL_RPM_BUILD_OPTIONS)
 # Find out what we are
 ID_LIKE := $(shell . /etc/os-release; echo $$ID_LIKE)
 # Of course that does not work for SLES-12
@@ -67,6 +68,7 @@ export LC_ALL = en_US.utf8
 endif
 TARGETS := $(RPMS) $(SRPM)
 endif
+
 all: $(TARGETS)
 
 %/:


### PR DESCRIPTION
Allow the caller to specify rpmbuild options.

Add python-srpm-macros to the CentOS 7 Dockerfile so that
linting specfiles that have python2/3 build support will find
the necessary macros.