### PR TITLE
Add ability to run tests

### DIFF
--- a/Dockerfile.leap.15
+++ b/Dockerfile.leap.15
@@ -31,6 +31,7 @@ RUN if ! grep "^#includedir /etc/sudoers.d" /etc/sudoers; then              \
         echo "#includedir /etc/sudoers.d" >> /etc/sudoers;                  \
     fi;                                                                     \
     echo "build ALL=(ALL) NOPASSWD: /usr/bin/build" > /etc/sudoers.d/build; \
+    echo "build ALL=(ALL) NOPASSWD: /bin/rpm" >> /etc/sudoers.d/build;      \
     chmod 0440 /etc/sudoers.d/build;                                        \
     visudo -c;                                                              \
     sudo -l -U build

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -16,6 +16,17 @@ ID_LIKE := $(shell . /etc/os-release; echo $$ID_LIKE)
 # Of course that does not work for SLES-12
 ID := $(shell . /etc/os-release; echo $$ID)
 VERSION_ID := $(shell . /etc/os-release; echo $$VERSION_ID)
+ifeq ($(ID),centos)
+DISTRO_ID := el$(VERSION_ID)
+define install_repo
+	if yum-config-manager --add-repo=$(1); then                  \
+	    repo_file=$$(ls -tar /etc/yum.repos.d/*.repo | tail -1); \
+	    sed -i -e 1d -e '$$s/^/gpgcheck=False/' $$repo_file;     \
+	else                                                         \
+	    exit 1;                                                  \
+	fi
+endef
+endif
 ifeq ($(findstring opensuse,$(ID)),opensuse)
 ID_LIKE := suse
 DISTRO_ID := sl$(VERSION_ID)
@@ -24,6 +35,11 @@ ifeq ($(ID),sles)
 # SLES-12 or 15 detected.
 ID_LIKE := suse
 DISTRO_ID := sle$(VERSION_ID)
+endif
+ifeq ($(ID_LIKE),suse)
+define install_repo
+	zypper --non-interactive ar $(1)
+endef
 endif
 
 BUILD_OS ?= leap.42.3
@@ -68,6 +84,35 @@ export LC_ALL = en_US.utf8
 endif
 TARGETS := $(RPMS) $(SRPM)
 endif
+
+define install_repos
+	for repo in $($(basename $(DISTRO_ID))_ADD_REPOS)                   \
+	            $(ADD_REPOS) $(1); do                                   \
+	    branch="master";                                                \
+	    build_number="lastSuccessfulBuild";                             \
+	    if [[ $$repo = *@* ]]; then                                     \
+	        branch="$${repo#*@}";                                       \
+	        repo="$${repo%@*}";                                         \
+	        if [[ $$branch = *:* ]]; then                               \
+	            build_number="$${branch#*:}";                           \
+	            branch="$${branch%:*}";                                 \
+	        fi;                                                         \
+	    fi;                                                             \
+	    case $(DISTRO_ID) in                                            \
+	        el7) distro="centos7";                                      \
+	        ;;                                                          \
+	        sle12.3) distro="sles12.3";                                 \
+	        ;;                                                          \
+	        sl42.3) distro="leap42.3";                                  \
+	        ;;                                                          \
+	        sl15.1) distro="leap15.1";                                  \
+	        ;;                                                          \
+	    esac;                                                           \
+	    baseurl=$${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$$repo/job/$$branch/; \
+	    baseurl+=$$build_number/artifact/artifacts/$$distro/;           \
+	    $(call install_repo,$$baseurl);                                 \
+        done
+endef
 
 all: $(TARGETS)
 
@@ -221,18 +266,22 @@ ls: $(TARGETS)
 
 ifeq ($(ID_LIKE),rhel fedora)
 chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
-	if [ -w /etc/mock/default.cfg ]; then                                    \
+	if [ -w /etc/mock/default.cfg ]; then                                        \
 	    echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/default.cfg;  \
-	    for repo in $(ADD_REPOS); do                                             \
+	    for repo in $(el7_ADD_REPOS) $(ADD_REPOS); do                            \
+	        branch="master";                                                     \
+	        build_number="lastSuccessfulBuild";                                  \
 	        if [[ $$repo = *@* ]]; then                                          \
 	            branch="$${repo#*@}";                                            \
 	            repo="$${repo%@*}";                                              \
-	        else                                                                 \
-	            branch="master";                                                 \
+	            if [[ $$branch = *:* ]]; then                                    \
+	                build_number="$${branch#*:}";                                \
+	                branch="$${branch%:*}";                                      \
+	            fi;                                                              \
 	        fi;                                                                  \
-	        echo -e "[$$repo:$$branch:lastSuccessful]\n\
-name=$$repo:$$branch:lastSuccessful\n\
-baseurl=$${JENKINS_URL}job/daos-stack/job/$$repo/job/$$branch/lastSuccessfulBuild/artifact/artifacts/centos7/\n\
+	        echo -e "[$$repo:$$branch:$$build_number]\n\
+name=$$repo:$$branch:$$build_number\n\
+baseurl=$${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$$repo/job/$$branch/$$build_number/artifact/artifacts/centos7/\n\
 enabled=1\n\
 gpgcheck = False\n" >> /etc/mock/default.cfg;                                        \
 	    done;                                                                    \
@@ -265,12 +314,16 @@ sl15_REPOS += --repo http://download.opensuse.org/update/leap/15.1/oss/         
 
 chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
 	add_repos="";                                                       \
-	for repo in $(ADD_REPOS); do                                        \
+	for repo in $($(basename $(DISTRO_ID))_ADD_REPOS) $(ADD_REPOS); do  \
+	    branch="master";                                                \
+	    build_number="lastSuccessfulBuild";                             \
 	    if [[ $$repo = *@* ]]; then                                     \
 	        branch="$${repo#*@}";                                       \
 	        repo="$${repo%@*}";                                         \
-	    else                                                            \
-	        branch="master";                                            \
+	        if [[ $$branch = *:* ]]; then                               \
+	            build_number="$${branch#*:}";                           \
+	            branch="$${branch%:*}";                                 \
+	        fi;                                                         \
 	    fi;                                                             \
 	    case $(DISTRO_ID) in                                            \
 	        sle12.3) distro="sles12.3";                                 \
@@ -280,12 +333,17 @@ chrootbuild: $(SRPM) $(CALLING_MAKEFILE)
 	        sl15.1) distro="leap15.1";                                  \
 	        ;;                                                          \
 	    esac;                                                           \
-	    baseurl=$${JENKINS_URL}job/daos-stack/job/$$repo/job/$$branch/; \
-	    baseurl+=lastSuccessfulBuild/artifact/artifacts/$$distro/;      \
+	    baseurl=$${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$$repo/job/$$branch/; \
+	    baseurl+=$$build_number/artifact/artifacts/$$distro/;           \
             add_repos+=" --repo $$baseurl";                                 \
         done;                                                               \
-	curl -O http://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/repodata/repomd.xml.key; \
-	sudo rpm --import repomd.xml.key;                                   \
+	for repo in $($(basename $(DISTRO_ID))_REPOS); do                   \
+	    if [ "$$repo" = "--repo" ]; then                                \
+	        continue;                                                   \
+	    fi;                                                             \
+	    curl -O "$$repo"/repodata/repomd.xml.key;                       \
+	    sudo rpm --import repomd.xml.key;                               \
+	done;                                                               \
 	sudo build $(BUILD_OPTIONS) $$add_repos                             \
 	     $($(basename $(DISTRO_ID))_REPOS)                              \
 	     --dist $(DISTRO_ID) $(RPM_BUILD_OPTIONS) $(SRPM)
@@ -319,6 +377,9 @@ endif
 ifndef DEBFULLNAME
 	$(error DEBFULLNAME is undefined)
 endif
+
+test:
+	@echo "No test defined for this module"
 
 show_version:
 	@echo $(VERSION)


### PR DESCRIPTION
By way of a "test:" target in the project Makefile.
- runs as root in a docker container
- provide helpers to installs project specified additional repos

Also support for per-distro additional repos.

Provide a default JENKINS_URL for when used outside of Jenkins.

Add gpg keys for specified additional repos on SUSE distros.