### PR TITLE
Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME    := libfabric
 SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
-sle12_REPOS := --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
-sl42_REPOS  := --repo https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
+sle12_REPOS := https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
+sl42_REPOS  := https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
 
 include Makefile_packaging.mk

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -8,9 +8,9 @@
 -include Makefile.local
 
 # alternate sources
-#OPENSUSE_MIRROR               ?= http://provo-mirror.opensuse.org
-#OPENSUSE_REPOS_MIRROR         ?= http://opensuse.mirror.liquidtelecom.com
-OPENSUSE_MIRROR               ?= http://download.opensuse.org
+#OPENSUSE_MIRROR               ?= https://provo-mirror.opensuse.org
+#OPENSUSE_REPOS_MIRROR         ?= https://opensuse.mirror.liquidtelecom.com
+OPENSUSE_MIRROR               ?= https://download.opensuse.org
 OPENSUSE_REPOS_MIRROR         ?= $(OPENSUSE_MIRROR)
 
 ifeq ($(DEB_NAME),)


### PR DESCRIPTION
Defaults for the mirror server and repos.
Make opensusue mirror location a variable for easy changing.
Change *ADD_REPOS to *PR_REPOS to better reflect what is expected there.
Use "local" Nexus repos as default for all distros' chrootbuild.
Don't require --repo on the SUSE distro repos.
Add packaging_check for using the obsoleted --repo keyword on distro
added repos.