### PR TITLE
CORCI-784 build: Fix for Ubuntu builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,17 @@ NAME    := libfabric
 SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
-sle12_REPOS := https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
-sl42_REPOS  := https://download.opensuse.org/repositories/science:/HPC/openSUSE_Leap_42.3/
+OSUSE_HPC_REPO := https://download.opensuse.org/repositories/science:/HPC
+LEAP_42_HPC_REPO := $(OSUSE_HPC_REPO)/openSUSE_Leap_42.3/
+
+ifeq ($(DAOS_STACK_LEAP_42_GROUP_REPO),)
+LEAP_42_REPOS  := $(LEAP_42_HPC_REPO)
+endif
+ifeq ($(DAOS_STACK_SLES_12_GROUP_REPO),)
+SLES_12_REPOS := $(LEAP_42_HPC_REPO)
+endif
+ifeq ($(DAOS_STACK_LEAP_15_GROUP_REPO),)
+LEAP_15_REPOS := $(OSUSE_HPC_REPO)/openSUSE_Leap_15.1/
+endif
 
 include Makefile_packaging.mk

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -186,7 +186,7 @@ $(DEB_TARBASE).orig.tar.$(SRC_EXT) : $(DEB_BUILD).tar.$(SRC_EXT)
 deb_detar: $(notdir $(SOURCE)) $(DEB_TARBASE).orig.tar.$(SRC_EXT)
 	# Unpack tarball
 	rm -rf ./$(DEB_TOP)/.patched ./$(DEB_TOP)/.detar
-	rm -rf ./$(DEB_BUILD)/* ./$(DEB_BUILD)/.pc
+	rm -rf ./$(DEB_BUILD)/* ./$(DEB_BUILD)/.pc ./$(DEB_BUILD)/.libs
 	mkdir -p $(DEB_BUILD)
 	tar -C $(DEB_BUILD) --strip-components=1 -xpf $<
 


### PR DESCRIPTION
Found another hidden directory to clean up for Ubuntu builds.
Should only be present in workspaces used for non chroot builds.

When a REPOSITORY server like NEXUS is configured to proxy for public
RPM repositories, don't also add them to the repository list.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>