### PR TITLE
Pass the CHROOT_NAME environment variable through

### DIFF
--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -35,8 +35,8 @@ RPMS              = $(eval RPMS := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86
 DEB_TOP          := _topdir/BUILD
 DEB_BUILD        := $(DEB_TOP)/$(NAME)-$(DEB_VERS)
 DEB_TARBASE      := $(DEB_TOP)/$(DEB_NAME)_$(DEB_VERS)
-SOURCE            = $(eval SOURCE := $(shell spectool -S -l $(SPEC) | sed -e 2,\$$d -e 's/.*:  *//'))$(SOURCE)
-PATCHES           = $(eval PATCHES := $(shell spectool -l $(SPEC) | sed -e 1d -e 's/.*:  *//' -e 's/.*\///'))$(PATCHES)
+SOURCE            = $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) spectool -S -l $(SPEC) | sed -e 2,\$$d -e 's/.*:  *//'))$(SOURCE)
+PATCHES           = $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) spectool -l $(SPEC) | sed -e 1d -e 's/.*:  *//' -e 's/.*\///'))$(PATCHES)
 SOURCES          := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES))
 ifeq ($(ID_LIKE),debian)
 DEBS             := $(addsuffix _$(DEB_VERS)-1_amd64.deb,$(shell sed -n '/-udeb/b; s,^Package:[[:blank:]],$(DEB_TOP)/,p' debian/control))


### PR DESCRIPTION

To sub-commands used to determine variable values so that they determine
the correct value for the target build platform.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>