### PR TITLE
Need to move the default CHROOT_NAME assignment

### DIFF
--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -6,6 +6,8 @@
 # Put site overrides (i.e. REPOSITORY_URL, DAOS_STACK_*_LOCAL_REPO) in here
 -include Makefile.local
 
+# default to Leap 15 distro for chrootbuild
+CHROOT_NAME ?= opensuse-leap-15.1-x86_64
 include packaging/Makefile_distro_vars.mk
 
 ifeq ($(DEB_NAME),)
@@ -19,7 +21,6 @@ RPM_BUILD_OPTIONS += $(EXTERNAL_RPM_BUILD_OPTIONS)
 
 # some defaults the caller can override
 BUILD_OS ?= leap.15
-CHROOT_NAME ?= opensuse-leap-15-x86_64
 PACKAGING_CHECK_DIR ?= ../packaging
 LOCAL_REPOS ?= true
 


### PR DESCRIPTION

To be before the include of packaging/Makefile_distro_vars.mk as that file
references that variable.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>