### PR TITLE
Pin mock and mock-core-configs to the 1.x version

### DIFF
--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -12,14 +12,10 @@ MAINTAINER daos-stack <daos@daos.groups.io>
 ARG UID=1000
 
 # Install basic tools
-RUN dnf -y install mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git python-srpm-macros rpmdevtools
+RUN dnf -y install mock\ \<\ 2 mock-core-configs\ \<\ 32 make \
+                   rpm-build curl createrepo rpmlint redhat-lsb-core git \
+                   python-srpm-macros rpmdevtools
 
-# Temporary fix for https://github.com/rpm-software-management/mock/issues/484
-RUN if [ ! -f /etc/mock/opensuse-leap-15.1-x86_64.cfg ]; then  \
-        ln /etc/mock/templates/opensuse-leap-15.1.tpl          \
-           /etc/mock/opensuse-leap-15.1-x86_64.cfg;            \
-    fi
 # Add build user (to keep rpmbuild happy)
 ENV USER build
 ENV PASSWD build


### PR DESCRIPTION
Since the 2.0 release for leap 15.1 building was a nightmare.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>