### PR TITLE
CORCI-938 build: Adding default test case.

### DIFF
--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -68,6 +68,7 @@ endef
 
 define install_repos
 	for repo in $($(DISTRO_BASE)_PR_REPOS)                              \
+	            $($(DISTRO_BASE)_LOCAL_REPOS)                           \
 	            $(PR_REPOS) $(1); do                                    \
 	    branch="master";                                                \
 	    build_number="lastSuccessfulBuild";                             \
@@ -387,9 +388,6 @@ endif
 
 test:
 	# Test the rpmbuild by installing the built RPM
-	rm -f /etc/yum.repos.d/*"${DAOS_STACK_LOCAL_REPO//\//_}"
-	yum-config-manager --add-repo="$REPOSITORY_URL"/"$DAOS_STACK_LOCAL_REPO"
-	echo "gpgcheck = False" >> /etc/yum.repos.d/*"${DAOS_STACK_LOCAL_REPO//\//_}".repo
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	yum -y install $(NAME)
 

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -384,7 +384,12 @@ ifndef DEBFULLNAME
 endif
 
 test:
-	@echo "No test defined for this module"
+	# Test the rpmbuild by installing the built RPM
+	rm -f /etc/yum.repos.d/*"${DAOS_STACK_LOCAL_REPO//\//_}"
+	yum-config-manager --add-repo="$REPOSITORY_URL"/"$DAOS_STACK_LOCAL_REPO"
+	echo "gpgcheck = False" >> /etc/yum.repos.d/*"${DAOS_STACK_LOCAL_REPO//\//_}".repo
+	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
+	yum -y install $(NAME)
 
 show_version:
 	@echo $(VERSION)

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -67,8 +67,10 @@ define distro_map
 endef
 
 define install_repos
+	for baseurl in $($(DISTRO_BASE)_LOCAL_REPOS); do                    \
+	    $(call install_repo,$$baseurl);                                 \
+	    done
 	for repo in $($(DISTRO_BASE)_PR_REPOS)                              \
-	            $($(DISTRO_BASE)_LOCAL_REPOS)                           \
 	            $(PR_REPOS) $(1); do                                    \
 	    branch="master";                                                \
 	    build_number="lastSuccessfulBuild";                             \


### PR DESCRIPTION
Adding a default test case to verify that the built RPM can be
installed.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>