### PR TITLE
Allow the caller to override the DPKG_GENSYMBOLS_CHECK_LEVEL

### DIFF
--- a/debian_chrootbuild
+++ b/debian_chrootbuild
@@ -40,4 +40,4 @@ cd "$DEB_TOP"
 # shellcheck disable=SC2086
 sudo pbuilder update --override-config $DISTRO_ID_OPT ${repo_args:+--othermirror "$repo_args"}
 # fail the build if the *.symbols file(s) need updating
-sudo DPKG_GENSYMBOLS_CHECK_LEVEL="${DPKG_GENSYMBOLS_CHECK_LEVEL:-4}" pbuilder build "$DEB_DSC"
+sudo DPKG_GENSYMBOLS_CHECK_LEVEL=4 pbuilder build "$DEB_DSC"


### PR DESCRIPTION
For when simply building the package is good enough, as in when building
a package  is just a test for correctness such as in pipeline-lib.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>