### PR TITLE
CORCI-985 Build: Fix repository testing

### DIFF
--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -79,7 +79,9 @@ define distro_map
 endef
 
 define install_repos
-	for baseurl in $($(DISTRO_BASE)_LOCAL_REPOS); do                    \
+	IFS='|' read -ra BASES <<< "$($(DISTRO_BASE)_LOCAL_REPOS)";         \
+	for baseurl in "$${BASES[@]}"; do                                   \
+	    baseurl="$${baseurl# *}";                                       \
 	    $(call install_repo,$$baseurl);                                 \
 	done
 	for repo in $($(DISTRO_BASE)_PR_REPOS)                              \


### PR DESCRIPTION
The repositories passed for testing are now a | delimited list.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>