### PR TITLE
CORCI-1036 Build: Always use local repository

### DIFF
--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -6,6 +6,13 @@ set -uex
 IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 
 if [ -w /etc/mock/"$CHROOT_NAME".cfg ]; then
+    # Remove the distro repos
+    if [[ $CHROOT_NAME =~ opensuse-leap-* ]]; then
+        ed /etc/mock/"$CHROOT_NAME".cfg << EOF
+/^# repos$/+2;/^"""$/-1d
+wq
+EOF
+    fi
     echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/"$CHROOT_NAME".cfg
     for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
         branch="master"


### PR DESCRIPTION
This changes the packaging procedure to always require that a local
repository has been setup to cache the upstream repositories for
the OpenSUSE Leap-15 distros.

This is to guard against intermittent upstream issues.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>