### PR TITLE
Remove ~ from DL_VERSION

### DIFF
--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -131,7 +131,7 @@ _topdir/SOURCES/%: % | _topdir/SOURCES/
 # At least one spec file, SLURM (sles), has a different version for the
 # download file than the version in the spec file.
 ifeq ($(DL_VERSION),)
-DL_VERSION = $(VERSION)
+DL_VERSION = $(subst ~,,$(VERSION))
 endif
 ifeq ($(DL_NAME),)
 DL_NAME = $(NAME)
@@ -389,6 +389,9 @@ show_common_rpm_args:
 
 show_version:
 	@echo '$(VERSION)'
+
+show_dl_version:
+	@echo '$(DL_VERSION)'
 
 show_release:
 	@echo '$(RELEASE)'


### PR DESCRIPTION
In RPM, pre-release tags are identified in versions with a ~.  These are
not typically in the actual upstream version.

So remove them when constructing the $(DL_VERSION).

Skip-PR-comments: true

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>