### PR TITLE
DAOS-7813 Build: Use local repo mirrors

### DIFF
--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -28,4 +28,3 @@ RUN usermod -a -G mock $USER
 RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
-RUN chmod g+w /etc/mock/*

--- a/Makefile_distro_vars.mk
+++ b/Makefile_distro_vars.mk
@@ -40,23 +40,17 @@ DISTRO_ID   := el8
 DISTRO_BASE := EL_8
 SED_EXPR    := 1s/$(DIST)//p
 endif
-ifeq ($(CHROOT_NAME),opensuse-leap-15.1-x86_64)
-VERSION_ID  := 15.1
-DISTRO_ID   := sl15.1
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
-endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
 VERSION_ID  := 15.2
 DISTRO_ID   := sl15.2
 DISTRO_BASE := LEAP_15
 SED_EXPR    := 1p
 endif
-ifeq ($(CHROOT_NAME),leap-42.3-x86_64)
-# TBD if support is ever resurrected
-endif
-ifeq ($(CHROOT_NAME),sles-12.3-x86_64)
-# TBD if support is ever resurrected
+ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
+VERSION_ID  := 15.3
+DISTRO_ID   := sl15.3
+DISTRO_BASE := LEAP_15
+SED_EXPR    := 1p
 endif
 endif
 ifeq ($(ID),centos)

--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -17,7 +17,7 @@ original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
 cfg_file="$mock_config_dir/${CHROOT_NAME}_daos.cfg"
 mkdir -p "$mock_config_dir"
 ln -sf /etc/mock/templates "$mock_config_dir/"
-ln -sf /etc/mock/templates/logging.ini "$mock_config_dir/"
+ln -sf /etc/mock/logging.ini "$mock_config_dir/"
 
 cp "$original_cfg_file" "$cfg_file"
 

--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -4,46 +4,54 @@ set -uex
 
 # shellcheck disable=SC2153
 IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
+repo_adds=()
+repo_dels=()
 
-if [ -w /etc/mock/"$CHROOT_NAME".cfg ]; then
-    # Remove the distro repos
-    if [[ $CHROOT_NAME =~ opensuse-leap-* ]]; then
-        ed /etc/mock/"$CHROOT_NAME".cfg << EOF
-/^# repos$/+2;/^"""$/-1d
-wq
-EOF
-    elif [[ $CHROOT_NAME =~ epel-8-* ]]; then
-        echo -e "config_opts['module_enable'] = ['javapackages-tools']\n" >> /etc/mock/"$CHROOT_NAME".cfg
-    fi
-    echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/"$CHROOT_NAME".cfg
-    for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
-        branch="master"
-        build_number="lastSuccessfulBuild"
-        if [[ $repo = *@* ]]; then
-            branch="${repo#*@}"
-            repo="${repo%@*}"
-            if [[ $branch = *:* ]]; then
-                build_number="${branch#*:}"
-                branch="${branch%:*}"
-            fi
+if [ -n "$REPOSITORY_URL" ] && [ -n "$DISTRO_REPOS" ]; then
+    repo_dels+=("--disablerepo=\*")
+fi
+
+: "${WORKSPACE:=$PWD}"
+mock_config_dir="$WORKSPACE/mock"
+original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
+cfg_file="$mock_config_dir/${CHROOT_NAME}_daos.cfg"
+mkdir -p "$mock_config_dir"
+ln -sf /etc/mock/templates "$mock_config_dir/"
+ln -sf /etc/mock/templates/logging.ini "$mock_config_dir/"
+
+cp "$original_cfg_file" "$cfg_file"
+
+echo -e "config_opts['yum.conf'] += \"\"\"\n" >> "$cfg_file"
+for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
+    branch="master"
+    build_number="lastSuccessfulBuild"
+    if [[ $repo = *@* ]]; then
+        branch="${repo#*@}"
+        repo="${repo%@*}"
+        if [[ $branch = *:* ]]; then
+            build_number="${branch#*:}"
+            branch="${branch%:*}"
         fi
-        echo -e "[$repo:$branch:$build_number]\n\
+    fi
+    repo_adds+=("--enablerepo $repo:$branch:$build_number")
+    echo -e "[$repo:$branch:$build_number]\n\
 name=$repo:$branch:$build_number\n\
 baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/\n\
 enabled=1\n\
-gpgcheck=False\n" >> /etc/mock/"$CHROOT_NAME".cfg
-    done
-    for repo in $JOB_REPOS "${distro_base_local_repos[@]}"; do
-        repo_name=${repo##*://}
-        repo_name=${repo_name//\//_}
-        echo -e "[${repo_name//@/_}]\n\
+gpgcheck=False\n" >> "$cfg_file"
+done
+for repo in $JOB_REPOS "${distro_base_local_repos[@]}"; do
+    repo_name=${repo##*://}
+    repo_name=${repo_name//\//_}
+    repo_adds+=("--enablerepo $repo_name")
+    echo -e "[${repo_name//@/_}]\n\
 name=${repo_name}\n\
 baseurl=${repo}\n\
-enabled=1\n" >> /etc/mock/"$CHROOT_NAME".cfg
-    done
-    echo "\"\"\"" >> /etc/mock/"$CHROOT_NAME".cfg
-else
-    echo "Unable to update /etc/mock/$CHROOT_NAME.cfg."
-    echo "You need to make sure it has the needed repos in it yourself."
-fi
-eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
+enabled=1\n" >> "$cfg_file"
+done
+echo "\"\"\"" >> "$cfg_file"
+
+# shellcheck disable=SC2086
+eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
+     "${repo_dels[*]}" "${repo_adds[*]}" \
+     $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"


### PR DESCRIPTION
Allow use of local repository mirrors when available for RPM building.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>