### PR TITLE
install dnf

### DIFF
--- a/Dockerfile.centos.7
+++ b/Dockerfile.centos.7
@@ -17,7 +17,7 @@ ARG UID=1000
 # Install basic tools
 RUN yum install -y epel-release
 RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git python-srpm-macros
+                   git python-srpm-macros dnf
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build


### PR DESCRIPTION
Installing dnf allows other builds to use dnf instead of yum.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>