### PR TITLE
CORCI-1103 build: Add CentOS 8.4, Leap 15.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,97 @@ pipeline {
                         }
                     }
                 } //stage('Build libfabric on CentOS 7')
-                stage('Build libfabric on Leap 15') {
+                stage('Build libfabric on CentOS 8.3') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.mockbuild'
+                            label 'docker_runner'
+                            args  '--group-add mock' +
+                                  ' --cap-add=SYS_ADMIN' +
+                                  ' --privileged=true'
+                            additionalBuildArgs dockerBuildArgs()
+                         }
+                    }
+                    steps {
+                        checkoutScm url: 'https://github.com/daos-stack/libfabric.git',
+                                    checkoutDir: "libfabric",
+                                    branch: commitPragma(pragma: 'libfabric-branch', def_val: 'master')
+                        sh label: env.STAGE_NAME,
+                           script: update_packaging + '''
+                                   rm -rf artifacts/centos8/ artifacts/centos8.3/
+                                   mkdir -p artifacts/centos8.3/
+                                   make CHROOT_NAME="epel-8-x86_64" \
+                                        DOT_VER="3" chrootbuild'''
+                    }
+                    post {
+                        unsuccessful {
+                            sh label: "Collect artifacts",
+                               script: '''mockroot=/var/lib/mock/epel-8-x86_64
+                                          artdir=$PWD/libfabric/artifacts/centos8.3
+                                          cp -af _topdir/SRPMS $artdir
+                                          (cd $mockroot/result/ &&
+                                           cp -r . $artdir)
+                                          (if cd $mockroot/root/builddir/build/BUILD/*/; then
+                                           find . -name configure -printf %h\\\\n | \
+                                           while read dir; do
+                                               if [ ! -f $dir/config.log ]; then
+                                                   continue
+                                               fi
+                                               tdir="$artdir/autoconf-logs/$dir"
+                                               mkdir -p $tdir
+                                               cp -a $dir/config.log $tdir/
+                                           done
+                                           fi)'''
+                            archiveArtifacts artifacts: 'libfabric/artifacts/centos8.3/**'
+                        }
+                    }
+                } //stage('Build libfabric on CentOS 8.3')
+                stage('Build libfabric on CentOS 8.4') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.mockbuild'
+                            label 'docker_runner'
+                            args  '--group-add mock' +
+                                  ' --cap-add=SYS_ADMIN' +
+                                  ' --privileged=true'
+                            additionalBuildArgs dockerBuildArgs()
+                         }
+                    }
+                    steps {
+                        checkoutScm url: 'https://github.com/daos-stack/libfabric.git',
+                                    checkoutDir: "libfabric",
+                                    branch: commitPragma(pragma: 'libfabric-branch', def_val: 'master')
+                        sh label: env.STAGE_NAME,
+                           script: update_packaging + '''
+                                   rm -rf artifacts/centos8/ artifacts/centos8.4/
+                                   mkdir -p artifacts/centos8.4/
+                                   make CHROOT_NAME="epel-8-x86_64" \
+                                        DOT_VER="4" chrootbuild'''
+                    }
+                    post {
+                        unsuccessful {
+                            sh label: "Collect artifacts",
+                               script: '''mockroot=/var/lib/mock/epel-8-x86_64
+                                          artdir=$PWD/libfabric/artifacts/centos8.4
+                                          cp -af _topdir/SRPMS $artdir
+                                          (cd $mockroot/result/ &&
+                                           cp -r . $artdir)
+                                          (if cd $mockroot/root/builddir/build/BUILD/*/; then
+                                           find . -name configure -printf %h\\\\n | \
+                                           while read dir; do
+                                               if [ ! -f $dir/config.log ]; then
+                                                   continue
+                                               fi
+                                               tdir="$artdir/autoconf-logs/$dir"
+                                               mkdir -p $tdir
+                                               cp -a $dir/config.log $tdir/
+                                           done
+                                           fi)'''
+                            archiveArtifacts artifacts: 'libfabric/artifacts/centos8.4/**'
+                        }
+                    }
+                } //stage('Build libfabric on CentOS 8.4')
+                stage('Build libfabric on Leap 15.2') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
@@ -114,19 +204,21 @@ pipeline {
                     steps {
                         checkoutScm url: 'https://github.com/daos-stack/libfabric.git',
                                     checkoutDir: "libfabric",
-                                    branch: commitPragma(pragma: 'libfabric-branch', def_val: 'master')
+                                    branch: commitPragma(pragma: 'libfabric-branch',
+                                                         def_val: 'master')
                         sh label: env.STAGE_NAME,
                            script: update_packaging + '''
-                                   rm -rf artifacts/leap15/
-                                   mkdir -p artifacts/leap15/
-                                   make chrootbuild'''
+                                   rm -rf artifacts/leap15/ artifacts/leap15.2/
+                                   mkdir -p artifacts/leap15.2/
+                                   make CHROOT_NAME="opensuse-leap-15.2-x86_64" \
+                                   chrootbuild'''
                     }
                     post {
                         unsuccessful {
                             sh label: "Collect artifacts",
                                script: '''mockbase=/var/tmp/build-root/home/abuild
                                           mockroot=$mockbase/rpmbuild
-                                          artdir=$PWD/artifacts/leap15
+                                          artdir=$PWD/artifacts/leap15.2
                                           (if cd $mockroot/BUILD; then
                                            find . -name configure -printf %h\\\\n | \
                                            while read dir; do
@@ -138,10 +230,54 @@ pipeline {
                                                cp -a $dir/config.log $tdir/
                                                done
                                            fi)'''
-                            archiveArtifacts artifacts: 'libfabric/artifacts/leap15/**'
+                            archiveArtifacts artifacts: 'libfabric/artifacts/leap15.2/**'
                         }
                     }
-                } //stage('Build libfabric on Leap 15')
+                } //stage('Build libfabric on Leap 15.2')
+                stage('Build libfabric on Leap 15.3') {
+                    agent {
+                        dockerfile {
+                            filename 'Dockerfile.mockbuild'
+                            label 'docker_runner'
+                            args  '--group-add mock' +
+                                  ' --cap-add=SYS_ADMIN' +
+                                  ' --privileged=true'
+                            additionalBuildArgs dockerBuildArgs()
+                        }
+                    }
+                    steps {
+                        checkoutScm url: 'https://github.com/daos-stack/libfabric.git',
+                                    checkoutDir: "libfabric",
+                                    branch: commitPragma(pragma: 'libfabric-branch',
+                                                         def_val: 'master')
+                        sh label: env.STAGE_NAME,
+                           script: update_packaging + '''
+                                   rm -rf artifacts/leap15/ artifacts/leap15.3/
+                                   mkdir -p artifacts/leap15.3/
+                                   make CHROOT_NAME="opensuse-leap-15.3-x86_64" \
+                                   chrootbuild'''
+                    }
+                    post {
+                        unsuccessful {
+                            sh label: "Collect artifacts",
+                               script: '''mockbase=/var/tmp/build-root/home/abuild
+                                          mockroot=$mockbase/rpmbuild
+                                          artdir=$PWD/artifacts/leap15.3
+                                          (if cd $mockroot/BUILD; then
+                                           find . -name configure -printf %h\\\\n | \
+                                           while read dir; do
+                                               if [ ! -f $dir/config.log ]; then
+                                                   continue
+                                               fi
+                                               tdir="$artdir/autoconf-logs/$dir"
+                                               mkdir -p $tdir
+                                               cp -a $dir/config.log $tdir/
+                                               done
+                                           fi)'''
+                            archiveArtifacts artifacts: 'libfabric/artifacts/leap15.3/**'
+                        }
+                    }
+                } //stage('Build libfabric on Leap 15.3')
                 stage('Build libfabric on Ubuntu 20.04') {
                     agent {
                         dockerfile {

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,4 @@ NAME    := libfabric
 SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
-OSUSE_HPC_REPO := https://download.opensuse.org/repositories/science:/HPC
-LEAP_42_HPC_REPO := $(OSUSE_HPC_REPO)/openSUSE_Leap_42.3/
-
-ifeq ($(DAOS_STACK_LEAP_42_GROUP_REPO),)
-LEAP_42_REPOS  := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_SLES_12_GROUP_REPO),)
-SLES_12_REPOS := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_LEAP_15_GROUP_REPO),)
-LEAP_15_REPOS := $(OSUSE_HPC_REPO)/openSUSE_Leap_15.1/
-endif
-
 include Makefile_packaging.mk

--- a/Makefile_distro_vars.mk
+++ b/Makefile_distro_vars.mk
@@ -38,18 +38,33 @@ DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID  := 8
 DISTRO_ID   := el8
 DISTRO_BASE := EL_8
+ifeq ($(DAOS_STACK_CENTOS_8_VERSION),8.$(DOT_VER))
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
 VERSION_ID  := 15.2
 DISTRO_ID   := sl15.2
 DISTRO_BASE := LEAP_15
+ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.2)
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
 VERSION_ID  := 15.3
 DISTRO_ID   := sl15.3
 DISTRO_BASE := LEAP_15
+ifeq ($(DAOS_STACK_LEAP_15_VERSION),15.3)
+DAOS_REPO_TYPE ?= STABLE
+else
+DAOS_REPO_TYPE ?= DEV
+endif
 SED_EXPR    := 1p
 endif
 endif

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -75,13 +75,12 @@ define distro_map
 	case $(DISTRO_ID) in               \
 	    el7) distro="centos7"          \
 	    ;;                             \
-	    el8) distro="centos8"          \
+	    el8) distro="centos8";         \
+		     if [ -n "$DOT_VER" ] ; then distro="centos8.${DOT_VER}"; fi \
 	    ;;                             \
-	    sle12.3) distro="sles12.3"     \
+	    sl15.2) distro=leap15.2        \
 	    ;;                             \
-	    sl42.3) distro="leap42.3"      \
-	    ;;                             \
-	    sl15.*) distro="leap15"        \
+	    sl15.*) distro=leap15.3        \
 	    ;;                             \
 	    ubuntu*) distro="$(DISTRO_ID)" \
 	    ;;                             \
@@ -131,8 +130,7 @@ all: $(TARGETS)
 	xz -z $<
 
 _topdir/SOURCES/%: % | _topdir/SOURCES/
-	rm -f $@
-	ln $< $@
+	if [ ! -d "$@" ]; then rm -f "$@"; ln "$<" "$@"; fi
 
 # At least one spec file, SLURM (sles), has a different version for the
 # download file than the version in the spec file.
@@ -309,8 +307,11 @@ ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
 DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
 $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
 endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
+ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_$(DAOS_REPO_TYPE)_REPO),)
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_$(DAOS_REPO_TYPE)_REPO)|
+endif
+ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_$(DAOS_REPO_TYPE)_REPO),)
+$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_$(DAOS_REPO_TYPE)_REPO)|
 endif
 ifneq ($(ID_LIKE),debian)
 ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
@@ -318,6 +319,8 @@ $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DA
 endif
 endif
 endif
+# else
+# Mirror repos for building a point release.
 endif
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)

--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -7,8 +7,21 @@ IFS=\| read -r -a distro_base_local_repos <<< "$DISTRO_BASE_LOCAL_REPOS"
 repo_adds=()
 repo_dels=()
 
+: "${REPOSITORY_URL:=}"
 if [ -n "$REPOSITORY_URL" ] && [ -n "$DISTRO_REPOS" ]; then
     repo_dels+=("--disablerepo=\*")
+elif [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
+    # Special code to force buiding on CentOS 8.3
+    if [ "${DOT_VER}" -eq 3 ]; then
+        repo_dels+=("--disablerepo=\*")
+        repo_base='http://mirror.centos.org/centos/8.3.2011/'
+        distro_base_local_repos=(\
+"${repo_base}BaseOS/x86_64/os/" \
+"${repo_base}AppStream/x86_64/os/" \
+"${repo_base}extras/x86_64/os/" \
+"${repo_base}PowerTools/x86_64/os/" \
+https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/ )
+    fi
 fi
 
 : "${WORKSPACE:=$PWD}"
@@ -21,6 +34,13 @@ ln -sf /etc/mock/logging.ini "$mock_config_dir/"
 
 cp "$original_cfg_file" "$cfg_file"
 
+if [ "${CHROOT_NAME}" == "epel-8-x86_64" ]; then
+  echo -e "config_opts['module_enable'] = ['javapackages-tools:201801']" \
+       >> "$cfg_file"
+  if [ -n "${DOT_VER}" ]; then
+    echo -e "config_opts['macros']['%dist'] = '.el8_${DOT_VER}'" >> "$cfg_file"
+  fi
+fi
 echo -e "config_opts['yum.conf'] += \"\"\"\n" >> "$cfg_file"
 for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     branch="master"
@@ -55,3 +75,6 @@ echo "\"\"\"" >> "$cfg_file"
 eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
      "${repo_dels[*]}" "${repo_adds[*]}" \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
+
+# For now just do an advisory check
+rpmlint "/var/lib/mock/${CHROOT_NAME}/result/"*.rpm || true


### PR DESCRIPTION
Add CentOS 8.4 and Leap 15.3 to the builds.
Set up the builds to support multiple dot versions for CentOS 8 and Leap
15.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>