### PR TITLE
DAOS-8915: Leap 15 builds should be on 15.3

### DIFF
--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -6,7 +6,7 @@
 
 # Pull base image
 FROM fedora:latest
-MAINTAINER daos-stack <daos@daos.groups.io>
+LABEL maintainer="daos@daos.groups.io>"
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000
@@ -28,3 +28,6 @@ RUN usermod -a -G mock $USER
 RUN grep use_nspawn /etc/mock/site-defaults.cfg || \
     echo "config_opts['use_nspawn'] = False" >> /etc/mock/site-defaults.cfg
 
+ARG CACHEBUST
+RUN dnf -y upgrade && \
+    dnf clean all

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,15 +169,15 @@ pipeline {
                            script: update_packaging + '''
                                    rm -rf artifacts/leap15/
                                    mkdir -p artifacts/leap15/
-                                   make CHROOT_NAME="opensuse-leap-15.2-x86_64" chrootbuild'''
+                                   make CHROOT_NAME="opensuse-leap-15.3-x86_64" chrootbuild'''
                     }
                     post {
                         success {
-                            sh 'ls -l /var/lib/mock/opensuse-leap-15.2-x86_64/result/'
+                            sh 'ls -l /var/lib/mock/opensuse-leap-15.3-x86_64/result/'
                         }
                         unsuccessful {
                             sh label: "Collect artifacts",
-                               script: '''mockroot=/var/lib/mock/opensuse-leap-15.2-x86_64
+                               script: '''mockroot=/var/lib/mock/opensuse-leap-15.3-x86_64
                                           artdir=$PWD/libfabric/artifacts/leap15
                                           cp -af _topdir/SRPMS $artdir
                                           (cd $mockroot/result/ &&

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,4 @@ NAME    := libfabric
 SRC_EXT := gz
 SOURCE   = https://github.com/ofiwg/$(NAME)/archive/v$(VERSION).tar.$(SRC_EXT)
 
-OSUSE_HPC_REPO := https://download.opensuse.org/repositories/science:/HPC
-LEAP_42_HPC_REPO := $(OSUSE_HPC_REPO)/openSUSE_Leap_42.3/
-
-ifeq ($(DAOS_STACK_LEAP_42_GROUP_REPO),)
-LEAP_42_REPOS  := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_SLES_12_GROUP_REPO),)
-SLES_12_REPOS := $(LEAP_42_HPC_REPO)
-endif
-ifeq ($(DAOS_STACK_LEAP_15_GROUP_REPO),)
-LEAP_15_REPOS := $(OSUSE_HPC_REPO)/openSUSE_Leap_15.1/
-endif
-
 include Makefile_packaging.mk

--- a/Makefile_distro_vars.mk
+++ b/Makefile_distro_vars.mk
@@ -27,30 +27,38 @@ SPECTOOL := spectool
 # DISTRO_BASE (i.e. EL_7)
 # from the CHROOT_NAME
 ifeq ($(CHROOT_NAME),epel-7-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 7
-DISTRO_ID   := el7
-DISTRO_BASE := EL_7
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 7
+DISTRO_ID       := el7
+DISTRO_BASE     := EL_7
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 7
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),epel-8-x86_64)
-DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
-VERSION_ID  := 8
-DISTRO_ID   := el8
-DISTRO_BASE := EL_8
-SED_EXPR    := 1s/$(DIST)//p
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 8
+DISTRO_ID       := el8
+DISTRO_BASE     := EL_8
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 8
+SED_EXPR        := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
-VERSION_ID  := 15.2
-DISTRO_ID   := sl15.2
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.2
+DISTRO_ID       := sl15.2
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.3-x86_64)
-VERSION_ID  := 15.3
-DISTRO_ID   := sl15.3
-DISTRO_BASE := LEAP_15
-SED_EXPR    := 1p
+VERSION_ID      := 15.3
+DISTRO_ID       := sl15.3
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.2
+SED_EXPR        := 1p
 endif
 endif
 ifeq ($(ID),centos)

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -44,6 +44,17 @@ EL_7_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-rep
 EL_8_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el8: *\(.*\)/\1/p')
 UBUNTU_20_04_PR_REPOS    ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-ubuntu20: *\(.*\)/\1/p')
 
+ifneq ($(PKG_GIT_COMMIT),)
+ifeq ($(GITHUB_PROJECT),)
+ifeq ($(GIT_PROJECT),)
+$(error You must set either GITHUB_PROJECT or GIT_PROJECT if you set PKG_GIT_COMMIT)
+endif
+endif
+BUILD_DEFINES     := --define "commit $(PKG_GIT_COMMIT)"
+RPM_BUILD_OPTIONS := $(BUILD_DEFINES)
+GIT_DIFF_EXCLUDES := $(PATCH_EXCLUDE_FILES:%=':!%')
+endif
+
 COMMON_RPM_ARGS  := --define "_topdir $$PWD/_topdir" $(BUILD_DEFINES)
 SPEC             := $(shell if [ -f $(NAME)-$(DISTRO_BASE).spec ]; then echo $(NAME)-$(DISTRO_BASE).spec; else echo $(NAME).spec; fi)
 VERSION           = $(eval VERSION := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p'))$(VERSION)
@@ -291,37 +302,80 @@ debs: $(DEBS)
 ls: $(TARGETS)
 	ls -ld $^
 
+ifneq ($(PKG_GIT_COMMIT),)
+# This not really intended to run in CI.  It's meant as a developer
+# convenience to generate the needed patch and add it to the repo to
+# be committed.
+$(VERSION)..$(PKG_GIT_COMMIT).patch:
+ifneq ($(GITHUB_PROJECT),)
+	# it really sucks that GitHub's "compare" returns such dirty patches
+	#curl -O 'https://github.com/$(GITHUB_PROJECT)/compare/$@'
+	git clone https://github.com/$(GITHUB_PROJECT).git
+else
+	git clone $(GIT_PROJECT)
+endif
+	set -x; pushd $(NAME) &&                              \
+	trap 'popd && rm -rf $(NAME)' EXIT;                   \
+	echo git diff $(VERSION)..$(PKG_GIT_COMMIT) --stat -- \
+	    $(GIT_DIFF_EXCLUDES );                            \
+	git diff $(VERSION)..$(PKG_GIT_COMMIT) --             \
+	    $(GIT_DIFF_EXCLUDES) > ../$@;                     \
+	popd;                                                 \
+	trap 'rm -rf $(NAME)' EXIT;                           \
+	git add $@
+patch: $(VERSION)..$(PKG_GIT_COMMIT).patch
+else
+patch:
+	echo "PKG_GIT_COMMIT is not defined"
+endif
+
 # *_LOCAL_* repos are locally built packages.
 # *_GROUP_* repos are a local mirror of a group of upstream repos.
 # *_GROUP_* repos may not supply a repomd.xml.key.
 ifeq ($(LOCAL_REPOS),true)
-ifneq ($(REPOSITORY_URL),)
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
-ifeq ($(ID_LIKE),debian)
-# $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
-# of values with spaces as environment variables
-$(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)/
-endif
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
-DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)|
-endif
-ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)|
-endif
-ifneq ($(ID_LIKE),debian)
-ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
-$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)|
-endif
-endif
-endif
-endif
+  ifneq ($(REPOSITORY_URL),)
+    # group repos are not working in Nexus so we hack in the group members directly below
+    #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO),)
+    #DISTRO_REPOS = $(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)
+    #$(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_DOCKER_$(DAOS_REPO_TYPE)_REPO)/
+    #endif
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+      ifeq ($(ID_LIKE),debian)
+        # $(DISTRO_BASE)_LOCAL_REPOS is a list separated by | because you cannot pass lists
+        # of values with spaces as environment variables
+        $(DISTRO_BASE)_LOCAL_REPOS := [trusted=yes]
+      else
+        $(DISTRO_BASE)_LOCAL_REPOS := $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_LOCAL_REPO)
+        DISTRO_REPOS = disabled # any non-empty value here works and is not used beyond testing if the value is empty or not
+      endif # ifeq ($(ID_LIKE),debian)
+      ifeq ($(DISTRO_BASE), EL_8)
+        # hack to use 8.3 non-group repos on EL_8
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-8.3-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-8.3-extras-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-8-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), EL_7)
+        # hack to use 7.9 non-group repos on EL_7
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/centos-7.9-base-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-extras-x86_64-proxy|$(REPOSITORY_URL)repository/centos-7.9-updates-x86_64-proxy|$(REPOSITORY_URL)repository/epel-el-7-x86_64-proxy)
+      else ifeq ($(DISTRO_BASE), LEAP_15)
+        # hack to use 15 non-group repos on LEAP_15
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(subst $(ORIG_TARGET_VER),$(DISTRO_VERSION),$(REPOSITORY_URL)repository/opensuse-15.2-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-oss-x86_64-provo-mirror-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-update-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-non-oss-x86_64-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-sle-update-proxy|$(REPOSITORY_URL)repository/opensuse-15.2-repo-backports-update-proxy)
+      else
+        # debian
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS) $(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO)
+      endif # ifeq ($(DISTRO_BASE), *)
+    endif #ifneq ($(DAOS_STACK_$(DISTRO_BASE)_$(DAOS_REPO_TYPE)_REPO),)
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_APPSTREAM_REPO)
+    endif
+    # group repos are not working in Nexus so we hack in the group members directly above
+    ifneq ($(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO),)
+      $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_$(DISTRO_BASE)_POWERTOOLS_REPO)
+    endif
+    ifneq ($(ID_LIKE),debian)
+      ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+        $(DISTRO_BASE)_LOCAL_REPOS := $($(DISTRO_BASE)_LOCAL_REPOS)|$(REPOSITORY_URL)$(DAOS_STACK_INTEL_ONEAPI_REPO)
+      endif # ifneq ($(DAOS_STACK_INTEL_ONEAPI_REPO),)
+    endif # ifneq ($(ID_LIKE),debian)
+  endif # ifneq ($(REPOSITORY_URL),)
+endif # ifeq ($(LOCAL_REPOS),true)
 ifeq ($(ID_LIKE),debian)
 chrootbuild: $(DEB_TOP)/$(DEB_DSC)
 	$(call distro_map)                                      \

--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -14,7 +14,7 @@ fi
 : "${WORKSPACE:=$PWD}"
 mock_config_dir="$WORKSPACE/mock"
 original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
-cfg_file="$mock_config_dir/${CHROOT_NAME}_daos.cfg"
+cfg_file="$mock_config_dir/${CHROOT_NAME}.cfg"
 mkdir -p "$mock_config_dir"
 ln -sf /etc/mock/templates "$mock_config_dir/"
 ln -sf /etc/mock/logging.ini "$mock_config_dir/"
@@ -57,6 +57,6 @@ done
 echo "\"\"\"" >> "$cfg_file"
 
 # shellcheck disable=SC2086
-eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}_daos" \
-     "${repo_dels[*]}" "${repo_adds[*]}" \
+eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}" \
+     ${repo_dels[*]} ${repo_adds[*]}                         \
      $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"


### PR DESCRIPTION
Also, stop using group repos and add a temporary hack to use proxy repos
directly.

Improve building packages from git commit hashes that preserves the
base-verison + patch paradigm.

Add a cachebust to the mock build Dockerfile to ensure that the mock
host is up-to-date.

Add support for the <distro>-version commit pragma.