### PR TITLE
DAOS-11151 build: Add cmake to Ubuntu default

### DIFF
--- a/Dockerfile.ubuntu.20.04
+++ b/Dockerfile.ubuntu.20.04
@@ -17,7 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
             dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
             make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget
+            python3-distutils rpm scons wget cmake
 
 # rpmdevtools
 RUN echo "deb [trusted=yes] ${REPO_URL}${REPO_UBUNTU_20_04} focal main" > /etc/apt/sources.list.d/daos-stack-ubuntu-stable-local.list


### PR DESCRIPTION
PMDK needs it for dh_auto_clean before chroot is built

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>