### PR TITLE
Add support for EL9

### DIFF
--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -1,11 +1,14 @@
 #
-# Copyright 2018-2022 Intel Corporation
+# Copyright 2018-2023 Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #
 
 # Pull base image
-FROM fedora:latest
+ARG FVERSION=38
+FROM fedora:$FVERSION
+# Needed for later use of FVERSION
+ARG FVERSION
 LABEL maintainer="daos@daos.groups.io"
 
 # Use local repo server if present

--- a/Dockerfile.ubuntu.20.04
+++ b/Dockerfile.ubuntu.20.04
@@ -42,9 +42,10 @@ RUN if [ -n "$REPO_FILE_URL" ]; then                                 \
 # Install basic tools
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             autoconf bash ca-certificates curl debhelper dh-make        \
-            dpkg-dev dh-python doxygen gcc git git-buildpackage locales \
-            make patch pbuilder pkg-config python3-dev python3-distro   \
-            python3-distutils rpm scons wget cmake valgrind rpmdevtools
+            dpkg-dev dh-python doxygen gcc git git-buildpackage         \
+            javahelper locales make patch pbuilder pkg-config           \
+            python3-dev python3-distro python3-distutils rpm scons wget \
+            cmake valgrind rpmdevtools
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000

--- a/Makefile_distro_vars.mk
+++ b/Makefile_distro_vars.mk
@@ -47,6 +47,18 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 8
 SED_EXPR        := 1s/$(DIST)//p
 endif
+ifeq ($(patsubst %epel-9-x86_64,,$(lastword $(subst +, ,$(CHROOT_NAME)))),)
+DIST            := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID      := 9
+DISTRO_ID       := el9
+DISTRO_BASE     := EL_9
+ifneq ($(DISTRO_VERSION_EL9),)
+override DISTRO_VERSION := $(DISTRO_VERSION_EL9)
+endif
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 9
+SED_EXPR        := 1s/$(DIST)//p
+endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.2-x86_64)
 VERSION_ID      := 15.2
 DISTRO_ID       := sl15.2

--- a/Makefile_packaging.mk
+++ b/Makefile_packaging.mk
@@ -39,6 +39,7 @@ PR_REPOS                 ?= $(shell git show -s --format=%B | sed -ne 's/^PR-rep
 LEAP_15_PR_REPOS         ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-leap15: *\(.*\)/\1/p')
 EL_7_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el7: *\(.*\)/\1/p')
 EL_8_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el8: *\(.*\)/\1/p')
+EL_9_PR_REPOS            ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-el9: *\(.*\)/\1/p')
 UBUNTU_20_04_PR_REPOS    ?= $(shell git show -s --format=%B | sed -ne 's/^PR-repos-ubuntu20: *\(.*\)/\1/p')
 REPO_FILES_PR            ?= $(shell git show -s --format=%B | sed -ne 's/^Repo-files-PR: *\(.*\)/\1/p')
 
@@ -64,10 +65,16 @@ RPMS              = $(eval RPMS := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86
 DEB_TOP          := _topdir/BUILD
 DEB_BUILD        := $(DEB_TOP)/$(NAME)-$(VERSION)
 DEB_TARBASE      := $(DEB_TOP)/$(DEB_NAME)_$(VERSION)
-SOURCE           ?= $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -S -l $(SPEC) | sed -e 2,\$$d -e 's/\#/\\\#/g' -e 's/.*:  *//'))$(SOURCE)
-PATCHES          ?= $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -l $(SPEC) | sed -ne 1d -e 's/.*:  *//' -e 's/.*\///' -e '/\.patch/p'))$(PATCHES)
-OTHER_SOURCES    := $(eval OTHER_SOURCES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -l $(SPEC) | sed -ne 1d -e 's/.*:  *//' -e 's/.*\///' -e '/\.patch/d' -e p))$(OTHER_SOURCES)
-SOURCES          := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES) $(OTHER_SOURCES))
+REAL_SOURCE      ?= $(eval REAL_SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -S -l $(SPEC) | sed -e 2,\$$d -e 's/\#/\\\#/g' -e 's/Source.*:  *//'))$(REAL_SOURCE)
+ifeq ($(ID_LIKE),debian)
+ifneq ($(DEB_SOURCE),)
+SOURCE           ?= $(DEB_SOURCE)
+endif
+endif
+SOURCE           ?= $(REAL_SOURCE)
+PATCHES          ?= $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -l $(SPEC) | sed -ne 1d -e '/already present/d' -e 's/.*:  *//' -e 's/.*\///' -e '/\.patch/p'))$(PATCHES)
+OTHER_SOURCES    := $(eval OTHER_SOURCES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) $(COMMON_RPM_ARGS) -l $(SPEC) | sed -ne 1d -e '/already present/d' -e '/^Patch.*:/d' -e 's/Source.*:  *//' -e 's/.*\///' -e p))$(OTHER_SOURCES)
+SOURCES          := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE) $(OTHER_SOURCES)) $(PATCHES))
 ifeq ($(ID_LIKE),debian)
 DEBS             := $(addsuffix _$(VERSION)-1_amd64.deb,$(shell sed -n '/-udeb/b; s,^Package:[[:blank:]],$(DEB_TOP)/,p' $(TOPDIR)/debian/control))
 DEB_PREV_RELEASE := $(shell cd $(TOPDIR) && dpkg-parsechangelog -S version)
@@ -84,7 +91,7 @@ define distro_map
 	case $(DISTRO_ID) in               \
 	    el7) distro="centos7"          \
 	    ;;                             \
-	    el8) distro="el8"              \
+	    el*) distro="$(DISTRO_ID)"     \
 	    ;;                             \
 	    sle12.3) distro="sles12.3"     \
 	    ;;                             \
@@ -154,7 +161,7 @@ ifeq ($(DL_NAME),)
 DL_NAME = $(NAME)
 endif
 
-$(notdir $(SOURCE)): $(SPEC) $(CALLING_MAKEFILE)
+$(notdir $(SOURCE) $(OTHER_SOURCES) $(REAL_SOURCE)): $(SPEC) $(CALLING_MAKEFILE)
 	# TODO: need to clean up old ones
 	$(SPECTOOL) -g $(SPEC)
 
@@ -181,27 +188,29 @@ $(DEB_TOP)/.patched: $(PATCHES) check-env deb_detar | \
 	$(DEB_BUILD)/debian/
 	mkdir -p ${DEB_BUILD}/debian/patches
 	mkdir -p $(DEB_TOP)/patches
-	for f in $(PATCHES); do \
-          rm -f $(DEB_TOP)/patches/*; \
-	  if git mailsplit -o$(DEB_TOP)/patches < "$$f" ;then \
-	      fn=$$(basename "$$f"); \
-	      for f1 in $(DEB_TOP)/patches/*;do \
-	        [ -e "$$f1" ] || continue; \
-	        f1n=$$(basename "$$f1"); \
-	        echo "$${fn}_$${f1n}" >> $(DEB_BUILD)/debian/patches/series ; \
-	        mv "$$f1" $(DEB_BUILD)/debian/patches/$${fn}_$${f1n}; \
-	      done; \
-	  else \
-	    fb=$$(basename "$$f"); \
-	    cp "$$f" $(DEB_BUILD)/debian/patches/ ; \
-	    echo "$$fb" >> $(DEB_BUILD)/debian/patches/series ; \
-	    if ! grep -q "^Description:\|^Subject:" "$$f" ;then \
-	      sed -i '1 iSubject: Auto added patch' \
-	        "$(DEB_BUILD)/debian/patches/$$fb" ;fi ; \
-	    if ! grep -q "^Origin:\|^Author:\|^From:" "$$f" ;then \
-	      sed -i '1 iOrigin: other' \
-	        "$(DEB_BUILD)/debian/patches/$$fb" ;fi ; \
-	  fi ; \
+	for f in $(PATCHES); do                                              \
+          rm -f $(DEB_TOP)/patches/*;                                    \
+	  if git mailsplit -o$(DEB_TOP)/patches < "$$f"; then                \
+	      fn=$$(basename "$$f");                                         \
+	      for f1 in $(DEB_TOP)/patches/*;do                              \
+	        [ -e "$$f1" ] || continue;                                   \
+	        f1n=$$(basename "$$f1");                                     \
+	        echo "$${fn}_$${f1n}" >> $(DEB_BUILD)/debian/patches/series; \
+	        mv "$$f1" $(DEB_BUILD)/debian/patches/$${fn}_$${f1n};        \
+	      done;                                                          \
+	  else                                                               \
+	    fb=$$(basename "$$f");                                           \
+	    cp "$$f" $(DEB_BUILD)/debian/patches/;                           \
+	    echo "$$fb" >> $(DEB_BUILD)/debian/patches/series;               \
+	    if ! grep -q "^Description:\|^Subject:" "$$f"; then              \
+	      sed -i '1 iSubject: Auto added patch'                          \
+	        "$(DEB_BUILD)/debian/patches/$$fb";                          \
+		fi;                                                              \
+	    if ! grep -q "^Origin:\|^Author:\|^From:" "$$f"; then            \
+	      sed -i '1 iOrigin: other'                                      \
+	        "$(DEB_BUILD)/debian/patches/$$fb";                          \
+		fi;                                                              \
+	  fi;                                                                \
 	done
 	touch $@
 
@@ -271,6 +280,9 @@ $(DEB_TOP)/$(DEB_DSC): $(CALLING_MAKEFILE) $(DEB_BUILD).tar.$(SRC_EXT) \
 	cd $(DEB_BUILD); dpkg-buildpackage -S --no-sign --no-check-builddeps
 
 $(SRPM): $(SPEC) $(SOURCES)
+	if [ -f bz-1955184_find-requires ]; then \
+	    chmod 755 bz-1955184_find-requires;  \
+	fi
 	rpmbuild -bs $(COMMON_RPM_ARGS) $(RPM_BUILD_OPTIONS) $(SPEC)
 
 srpm: $(SRPM)
@@ -413,6 +425,7 @@ packaging_check:
 	          --exclude install                             \
 	          --exclude packaging                           \
 	          --exclude utils                               \
+	          --exclude .vscode                             \
 	          -bur $(PACKAGING_CHECK_DIR)/ packaging/; then \
 	    exit 1;                                             \
 	fi
@@ -462,6 +475,9 @@ show_rpms:
 
 show_source:
 	@echo '$(SOURCE)'
+
+show_real_source:
+	@echo '$(REAL_SOURCE)'
 
 show_patches:
 	@echo '$(PATCHES)'

--- a/debian_chrootbuild
+++ b/debian_chrootbuild
@@ -12,6 +12,7 @@ sudo pbuilder create                        \
     $DISTRO_ID_OPT
 
 repo_args=""
+repos_added=()
 for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     branch="master"
     build_number="lastSuccessfulBuild"
@@ -23,6 +24,11 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
             branch="${branch%:*}"
         fi
     fi
+    if [[ " ${repos_added[*]} " = *\ ${repo}\ * ]]; then
+        # don't add duplicates, first found wins
+        continue
+    fi
+    repos_added+=("$repo")
     repo_args="$repo_args|deb [trusted=yes] ${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/ ./"
 done
 
@@ -31,6 +37,13 @@ repo_args+="|$(curl -sSf "$REPO_FILE_URL"daos_ci-"$DISTRO"-artifactory.list |
                 -e 's/signed-by=.*\.gpg/trusted=yes/'                       |
             sed -e ':a; N; $!ba; s/\n/|/g')"
 for repo in $JOB_REPOS; do
+    repo_name=${repo##*://}
+    repo_name=${repo_name//\//_}
+    if [[ " ${repos_added[*]} " = *\ ${repo_name}\ * ]]; then
+        # don't add duplicates, first found wins
+        continue
+    fi
+    repos_added+=("$repo_name")
     repo_args+="|deb ${repo} $VERSION_CODENAME main"
 done
 # NB: This PPA is needed to support modern go toolchains on ubuntu 20.04.

--- a/install
+++ b/install
@@ -5,7 +5,7 @@
 set -e
 
 packaging_dir=${0%/*}
-cp -a $packaging_dir .
-rm -rf packaging/{debian/,.git/,Jenkinsfile,Makefile,README.md,_topdir,v1.8.0.tar.gz,install,packaging.code-workspace}
+cp -a "$packaging_dir" .
+rm -rf packaging/{debian/,.git/,Jenkinsfile,Makefile,README.md,_topdir,v1.8.0.tar.gz,install,packaging.code-workspace,utils,.vscode}
 rm -f packaging/packaging
-ln $packaging_dir/.git/hooks/* .git/hooks/
+ln "$packaging_dir"/.git/hooks/* .git/hooks/

--- a/rpm_chrootbuild
+++ b/rpm_chrootbuild
@@ -2,17 +2,13 @@
 
 set -uex
 
-mock_config_dir="${WORKSPACE:-$PWD}/mock"
-original_cfg_file="/etc/mock/${CHROOT_NAME}.cfg"
-cfg_file="$mock_config_dir/${CHROOT_NAME}.cfg"
-mkdir -p "$mock_config_dir"
-ln -sf /etc/mock/templates "$mock_config_dir/"
-ln -sf /etc/mock/logging.ini "$mock_config_dir/"
+original_cfg_file="/etc/mock/$CHROOT_NAME.cfg"
+cfg_file=mock.cfg
 
 cp "$original_cfg_file" "$cfg_file"
 
 if [[ $CHROOT_NAME == *epel-8-x86_64 ]]; then
-    cat <<EOF >> "$cfg_file"
+    cat <<EOF >> mock.cfg
 config_opts['module_setup_commands'] = [
   ('enable', 'javapackages-tools:201801'),
   ('disable',  'go-toolset')
@@ -60,11 +56,12 @@ if [ -n "${ARTIFACTORY_URL:-}" ] && "$LOCAL_REPOS"; then
                 REPO_FILE_URL="file://$(readlink -e "$REPO_FILES_PR")/"
             fi
         fi
-        curl -sSf "$REPO_FILE_URL"daos_ci-"$DISTRO"-mock-artifactory.repo >> "$cfg_file"
+        curl -sSf "${REPO_FILE_URL}daos_ci-$DISTRO"-mock-artifactory.repo >> "$cfg_file"
         repo_adds+=("--enablerepo *-artifactory")
     fi
 fi
 
+repos_added=()
 for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
     branch="master"
     build_number="lastSuccessfulBuild"
@@ -76,20 +73,30 @@ for repo in $DISTRO_BASE_PR_REPOS $PR_REPOS; do
             branch="${branch%:*}"
         fi
     fi
-    repo_adds+=("--enablerepo $repo:$branch:$build_number")
-    echo -e "[$repo:$branch:$build_number]\n\
-name=$repo:$branch:$build_number\n\
-baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/$DISTRO/\n\
+    if [[ " ${repos_added[*]} " = *\ ${repo}\ * ]]; then
+        # don't add duplicates, first found wins
+        continue
+    fi
+    repos_added+=("$repo")
+    repo_adds+=("--enablerepo $repo:${branch//[@\/]/_}:$build_number")
+    echo -e "[$repo:${branch//[@\/]/_}:$build_number]\n\
+name=$repo:${branch//[@\/]/_}:$build_number\n\
+baseurl=${JENKINS_URL:-https://build.hpdd.intel.com/}job/daos-stack/job/$repo/job/${branch//\//%2F}/$build_number/artifact/artifacts/$DISTRO/\n\
 enabled=1\n\
 gpgcheck=False\n" >> "$cfg_file"
 done
 for repo in $JOB_REPOS; do
     repo_name=${repo##*://}
     repo_name=${repo_name//\//_}
+    if [[ " ${repos_added[*]} " = *\ ${repo_name}\ * ]]; then
+        # don't add duplicates, first found wins
+        continue
+    fi
+    repos_added+=("$repo_name")
     repo_adds+=("--enablerepo $repo_name")
-    echo -e "[${repo_name//@/_}]\n\
+    echo -e "[${repo_name//[@\/]/_}]\n\
 name=${repo_name}\n\
-baseurl=${repo}\n\
+baseurl=${repo//\//%2F}\n\
 enabled=1\n" >> "$cfg_file"
 done
 echo "\"\"\"" >> "$cfg_file"
@@ -97,7 +104,22 @@ echo "\"\"\"" >> "$cfg_file"
 if [ -n "$DISTRO_VERSION" ]; then
     releasever_opt=("--config-opts=releasever=$DISTRO_VERSION")
 fi
+
+bs_dir=/scratch/mock/cache/"${CHROOT_NAME}"-bootstrap
+if ls -l /scratch/mock/cache/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz; then
+    mkdir -p "/var/cache/mock/${CHROOT_NAME}-bootstrap"
+    flock "$bs_dir" -c "cp -a $bs_dir/root_cache /var/cache/mock/${CHROOT_NAME}-bootstrap"
+fi
+
 # shellcheck disable=SC2086
-eval mock --configdir "$mock_config_dir" -r "${CHROOT_NAME}"           \
-     ${repo_dels[*]} ${repo_adds[*]} --disablerepo=\*-debug*           \
+eval mock -r "$cfg_file" ${repo_dels[*]} ${repo_adds[*]} --disablerepo=\*-debug* \
      "${releasever_opt[@]}" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
+
+date
+if ls -l /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz &&
+   [ -d /scratch/ ]; then
+    mkdir -p /scratch/mock/cache/"${CHROOT_NAME}"-bootstrap/
+    if ! cmp /var/cache/mock/"${CHROOT_NAME}"-bootstrap/root_cache/cache.tar.gz "$bs_dir"/root_cache/cache.tar.gz; then
+        flock "$bs_dir" -c "cp -a /var/cache/mock/${CHROOT_NAME}-bootstrap/root_cache $bs_dir/"
+    fi
+fi


### PR DESCRIPTION
If multiple pragmas reference a repo, only add the first one.  By this
measure, PR-Repos-$distro should be specified before PR-Repos.

Default mock buiding to Fedora 38 but allow override for, say Leap 15.4
that can only build on mock on Fedora 37.

Updated Ubuntu buid environment packages.

Save and restore mock root_cache tarballs to speed up builds.

Simplify mock configuration file build and use.

Skip-PR-comments: true

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>