### PR TITLE
DAOS-16744 ci: Enable change of origin

### DIFF
--- a/get_base_branch
+++ b/get_base_branch
@@ -4,7 +4,7 @@
 
 set -eux -o pipefail
 IFS=' ' read -r -a add_bases <<< "${1:-}"
-origin=origin
+origin="${ORIGIN:-origin}"
 mapfile -t all_bases < <(echo "master"
                          git branch -r | sed -ne "/^  $origin\\/release\\/[0-9]/s/^  $origin\\///p")
 all_bases+=("${add_bases[@]}")


### PR DESCRIPTION
The githooks support DAOS_ORIGIN setting to change default. This will be passed as ORIGIN to this script so only set to origin if it's not set.