### PR TITLE
SRE-3223 ci: Use DAOS_HTTPS_PROXY and DAOS_NO_PROXY

### DIFF
--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -16,6 +16,25 @@ LABEL maintainer="daos@daos.groups.io"
 ARG REPO_FILE_URL
 ARG DAOS_LAB_CA_FILE_URL
 ARG REPOSITORY_NAME
+
+# Accept DAOS_NO_PROXY at build time
+ARG DAOS_NO_PROXY
+# Propagate into the build environment
+ENV no_proxy=${DAOS_NO_PROXY}
+ENV NO_PROXY=${DAOS_NO_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "no_proxy=${DAOS_NO_PROXY}" >> /etc/environment && \
+    echo "NO_PROXY=${DAOS_NO_PROXY}" >> /etc/environment
+
+# Accept DAOS_HTTPS_PROXY at build time
+ARG DAOS_HTTPS_PROXY
+# Propagate into the build environment
+ENV https_proxy=${DAOS_HTTPS_PROXY}
+ENV HTTPS_PROXY=${DAOS_HTTPS_PROXY}
+# Persist into /etc/environment for use by shells and services
+RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
+    echo "HTTPS_PROXY=${DAOS_HTTPS_PROXY}" >> /etc/environment
+
 # script to install OS updates basic tools and daos dependencies
 # COPY ./utils/scripts/install-fedora.sh /tmp/install.sh
 # script to setup local repo if available

--- a/Dockerfile.mockbuild
+++ b/Dockerfile.mockbuild
@@ -40,14 +40,13 @@ RUN echo "https_proxy=${DAOS_HTTPS_PROXY}" >> /etc/environment && \
 # script to setup local repo if available
 COPY ./packaging/scripts/repo-helper-fedora.sh /tmp/repo-helper.sh
 
-RUN chmod +x /tmp/repo-helper.sh &&                 \
-    /tmp/repo-helper.sh &&                          \
+RUN chmod +x /tmp/repo-helper.sh && \
+    /tmp/repo-helper.sh &&          \
     rm -f /tmp/repo-helper.sh
 
 # Install basic tools
-RUN dnf -y install mock make                                        \
-                   rpm-build createrepo rpmlint redhat-lsb-core git \
-                   python-srpm-macros rpmdevtools &&                \
+RUN dnf -y install mock make rpm-build createrepo rpmlint git \
+        python-srpm-macros rpmdevtools &&                     \
     dnf -y clean all
 
 # use same UID as host and default value of 1000 if not specified

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@grom72/sre-3215") _
 
 String updatePackaging(String dir) {
     return """rm -rf ${dir}/packaging/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,6 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
-@Library(value="pipeline-lib@grom72/sre-3215") _
 
 String updatePackaging(String dir) {
     return """rm -rf ${dir}/packaging/

--- a/scripts/repo-helper-fedora.sh
+++ b/scripts/repo-helper-fedora.sh
@@ -44,7 +44,7 @@ install_curl() {
 install_optional_ca() {
     ca_storage="/etc/pki/ca-trust/source/anchors/"
     if [ -n "$DAOS_LAB_CA_FILE_URL" ]; then
-        curl -k --noproxy '*' -sSf -o "${ca_storage}lab_ca_file.crt" \
+        curl -k -sSf -o "${ca_storage}lab_ca_file.crt" \
             "$DAOS_LAB_CA_FILE_URL"
         update-ca-trust
     fi
@@ -60,7 +60,7 @@ if [ -n "$REPO_FILE_URL" ]; then
     install_optional_ca
     mkdir -p /etc/yum.repos.d
     pushd /etc/yum.repos.d/
-    curl -k --noproxy '*' -sSf                                  \
+    curl -k -sSf                                  \
          -o "daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"  \
          "{$REPO_FILE_URL}daos_ci-fedora${archive}-${REPOSITORY_NAME}.repo"
     disable_repos /etc/yum.repos.d/


### PR DESCRIPTION
The `DAOS_HTTPS_PROXY` and `DAOS_NO_PROXY` variables provided by Jenkins define a complete
proxy configurations for CI environment.
These variables are converted inside Dockers to Linux native variables `NO_PROXY` and `HTTPS_PROXY`.